### PR TITLE
스트레칭 진행 윈도우 UI 구현

### DIFF
--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -14,6 +14,7 @@ struct APPROApp: App {
     @Environment(\.dismissImmersiveSpace) private var dismissImmersiveSpace
     @Environment(\.openWindow) private var openWindow
     @Environment(\.dismissWindow) private var dismissWindow
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var appState = AppState()
 
@@ -34,7 +35,7 @@ struct APPROApp: App {
         }
         
         WindowGroup(id: appState.stretchingProcessWindowID) {
-            if let stretching = appState.currentStretching {
+            if appState.currentStretching != nil {
                 StretchingProcessView()
                     .environment(appState)
             }
@@ -49,19 +50,19 @@ struct APPROApp: App {
     }
     
     private func configureChoosingStretchingPartScene() {
-        dismissWindow(id: appState.stretchingProcessWindowID)
         Task {
+            openWindow(id: appState.stretchingPartsWindowID)
             await dismissImmersiveSpace()
+            dismissWindow(id: appState.stretchingProcessWindowID)
         }
-        openWindow(id: appState.stretchingPartsWindowID)
     }
     
     private func configureStretchingScene() {
-        dismissWindow(id: appState.stretchingPartsWindowID)
         Task {
+            openWindow(id: appState.stretchingProcessWindowID)
             await openImmersiveSpace(id: appState.immersiveSpaceID)
+            dismissWindow(id: appState.stretchingPartsWindowID)
         }
-        openWindow(id: appState.stretchingProcessWindowID)
     }
     
 }

--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -24,7 +24,11 @@ struct APPROApp: App {
                 .environment(appState)
         }
         .windowStyle(.plain)
-        .windowResizability(.contentSize)
+        .defaultWindowPlacement { content, context in
+            guard let stretchingProcessWindow = context.windows.first(where: { $0.id == appState.stretchingProcessWindowID }) else { return .init(.none) }
+            
+            return .init(.trailing(stretchingProcessWindow))
+        }
         .onChange(of: appState.appPhase) { _, newPhase in
             switch newPhase {
             case .choosingStretchingPart:
@@ -41,6 +45,11 @@ struct APPROApp: App {
             }
         }
         .windowStyle(.plain)
+        .defaultWindowPlacement { _, context in
+            guard let stretchingPartsWindow = context.windows.first(where: { $0.id == appState.stretchingPartsWindowID }) else { return .init(.none) }
+            
+            return .init(.leading(stretchingPartsWindow))
+        }
         .windowResizability(.contentSize)
         
         ImmersiveSpace(id: appState.immersiveSpaceID) {
@@ -52,8 +61,8 @@ struct APPROApp: App {
     private func configureChoosingStretchingPartScene() {
         Task {
             openWindow(id: appState.stretchingPartsWindowID)
-            await dismissImmersiveSpace()
             dismissWindow(id: appState.stretchingProcessWindowID)
+            await dismissImmersiveSpace()
         }
     }
     

--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -24,10 +24,11 @@ struct APPROApp: App {
                 .environment(appState)
         }
         .windowStyle(.plain)
+        .windowResizability(.contentSize)
         .defaultWindowPlacement { content, context in
             guard let stretchingProcessWindow = context.windows.first(where: { $0.id == appState.stretchingProcessWindowID }) else { return .init(.none) }
             
-            return .init(.trailing(stretchingProcessWindow))
+            return .init(.leading(stretchingProcessWindow))
         }
         .onChange(of: appState.appPhase) { _, newPhase in
             switch newPhase {
@@ -48,7 +49,7 @@ struct APPROApp: App {
         .defaultWindowPlacement { _, context in
             guard let stretchingPartsWindow = context.windows.first(where: { $0.id == appState.stretchingPartsWindowID }) else { return .init(.none) }
             
-            return .init(.leading(stretchingPartsWindow))
+            return .init(.trailing(stretchingPartsWindow))
         }
         .windowResizability(.contentSize)
         

--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -34,7 +34,10 @@ struct APPROApp: App {
         }
         
         WindowGroup(id: appState.stretchingProcessWindowID) {
-            // TODO: 스트레칭 진행 윈도우 구현 및 추가
+            if let stretching = appState.currentStretching {
+                StretchingProcessView()
+                    .environment(appState)
+            }
         }
         .windowStyle(.plain)
         .windowResizability(.contentSize)

--- a/APPRO/APPRO/Data & State/AppState.swift
+++ b/APPRO/APPRO/Data & State/AppState.swift
@@ -18,4 +18,24 @@ final class AppState {
     
     var appPhase: AppPhase = .choosingStretchingPart
     
+    var currentStretching: Stretching? {
+        if case .isStretching(let stretching) = appPhase {
+            return stretching
+        } else {
+            return nil
+        }
+    }
+    
+    var doneCount = 0
+    private(set) var maxCount = 0
+    
+    func resetStretchingCount() {
+        if case(.isStretching(let stretching)) = appPhase {
+            doneCount = 0
+            maxCount = (stretching == .eyes || stretching == .wrist) ? 12 : 3
+        } else {
+            dump("resetStretchingCount unexpectedly called")
+        }
+    }
+    
 }

--- a/APPRO/APPRO/Data & State/AppState.swift
+++ b/APPRO/APPRO/Data & State/AppState.swift
@@ -30,7 +30,7 @@ final class AppState {
     private(set) var maxCount = 0
     
     func resetStretchingCount() {
-        if case(.isStretching(let stretching)) = appPhase {
+        if let stretching = currentStretching {
             doneCount = 0
             maxCount = (stretching == .eyes || stretching == .wrist) ? 12 : 3
         } else {

--- a/APPRO/APPRO/Views/StretchingParts/StretchingCard.swift
+++ b/APPRO/APPRO/Views/StretchingParts/StretchingCard.swift
@@ -31,7 +31,6 @@ struct StretchingCard: View {
                 .foregroundStyle(.white)
                 .background(.thinMaterial)
             }
-            .aspectRatio(1.67, contentMode: .fit)
             .background {
                 Image(stretching.backgroundImageName)
                     .resizable()
@@ -39,6 +38,7 @@ struct StretchingCard: View {
             }
             .clipShape(RoundedRectangle(cornerRadius: 20))
         }
+        .frame(width: 498, height: 280)
         .buttonStyle(.plain)
         .buttonBorderShape(.roundedRectangle)
     }

--- a/APPRO/APPRO/Views/StretchingProcess/SetCheckCircle.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/SetCheckCircle.swift
@@ -1,0 +1,35 @@
+//
+//  SetCheckCircle.swift
+//  APPRO
+//
+//  Created by 정상윤 on 10/24/24.
+//
+
+import SwiftUI
+
+struct SetCheckCircle: View {
+    
+    let isChecked: Bool
+    
+    var body: some View {
+        Circle()
+            .frame(width: 66, height: 66)
+            .foregroundStyle(.thickMaterial)
+            .overlay {
+                if isChecked {
+                    Image(systemName: "checkmark")
+                        .resizable()
+                        .frame(width: 30, height: 30)
+                        .aspectRatio(contentMode: .fit)
+                        .fontWeight(.light)
+                }
+            }
+            .clipShape(.circle)
+            .glassBackgroundEffect()
+    }
+    
+}
+
+#Preview(windowStyle: .plain) {
+    SetCheckCircle(isChecked: true)
+}

--- a/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
@@ -47,7 +47,7 @@ struct StretchingProcessView: View {
                     }
                 }
             }
-            .frame(width: 632)
+            .frame(width: 550)
             .padding(24)
             .padding(.bottom, 24)
             .glassBackgroundEffect()

--- a/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
@@ -1,0 +1,69 @@
+//
+//  StretchingProcessView.swift
+//  APPRO
+//
+//  Created by 정상윤 on 10/24/24.
+//
+
+import SwiftUI
+import RealityKit
+
+struct StretchingProcessView: View {
+    
+    @Environment(AppState.self) private var appState
+    
+    var body: some View {
+        if let stretching = appState.currentStretching {
+            VStack(spacing: 20) {
+                ZStack(alignment: .center) {
+                    HStack {
+                        Button("Dismiss Immersive Space", systemImage: "multiply") {
+                            appState.appPhase = .choosingStretchingPart
+                        }
+                        .labelStyle(.iconOnly)
+                        
+                        Spacer()
+                    }
+                    Text("\(stretching.title) Stretch")
+                        .font(.largeTitle)
+                }
+                
+                if stretching == .eyes || stretching == .wrist {
+                    Text("Score")
+                        .font(.title)
+                        .opacity(0.96)
+                    Text("\(appState.doneCount) / \(appState.maxCount)")
+                        .font(.system(size: 60))
+                        .fontWeight(.semibold)
+                } else {
+                    Text("Sets")
+                        .font(.title)
+                        .opacity(0.96)
+                    HStack(spacing: 15) {
+                        ForEach(0..<appState.maxCount, id: \.self) { idx in
+                            SetCheckCircle(isChecked: appState.doneCount == idx + 1)
+                        }
+                    }
+                }
+            }
+            .frame(width: 632)
+            .padding(24)
+            .padding(.bottom, 24)
+            .glassBackgroundEffect()
+            .onAppear {
+                appState.resetStretchingCount()
+                appState.doneCount = 1
+            }
+        }
+    }
+    
+}
+
+#Preview(windowStyle: .plain) {
+    let appState = AppState()
+    
+    appState.appPhase = .isStretching(.shoulder)
+    
+    return StretchingProcessView()
+        .environment(appState)
+}

--- a/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
@@ -11,6 +11,7 @@ import RealityKit
 struct StretchingProcessView: View {
     
     @Environment(AppState.self) private var appState
+    @Environment(\.scenePhase) private var scenePhase
     
     var body: some View {
         if let stretching = appState.currentStretching {
@@ -53,6 +54,14 @@ struct StretchingProcessView: View {
             .onAppear {
                 appState.resetStretchingCount()
                 appState.doneCount = 1
+            }
+            .onChange(of: scenePhase) { _, scenePhase in
+                switch scenePhase {
+                case .inactive, .background:
+                    appState.appPhase = .choosingStretchingPart
+                default:
+                    break
+                }
             }
         }
     }


### PR DESCRIPTION
# 이슈
- close #6 

# 작업 사항
- StretchingProcessView 구현
- AppState 스트레칭 점수/횟수 변수 및 초기화 함수 추가
- 윈도우 open / dismiss 오류 수정
- 윈도우 defaultWindowPlacement 추가

# 고민 or 참고 사항 (선택)
- 스트레칭 진행 윈도우의 하단 닫기 버튼을 클릭했을 때의 동작을 어떻게 처리할지 고민했고, 앱이 꺼지는 것이 아닌 Shared Space로 돌아가 스트레칭 부위 윈도우를 열어주도록 구현했습니다. 그 과정에서 ScenePhase를 App 인스턴스에서 호출하는 것과 View 인스턴스에서 호출했을 때의 차이점이 있다는 것을 알았습니다. (좀 더 자세히 테스트해봐야하긴 합니다... 시간 부족😢) [관련 내용](https://illustrious-fifth-36f.notion.site/onDisappear-ScenePhase-onChange-6865aa1e0ac943f59ebe7dbafde1b088?pvs=4)
- [윈도우 open / dismiss 트러블슈팅 정리](https://illustrious-fifth-36f.notion.site/dismiss-open-6af033f716c244e5acbedc9255f52bf6?pvs=4)
- 현재 visionOS에서 윈도우 위치 관련 구현에 제약이 아주아주 많기 때문에 제가 어찌할 방법이 없어서 일단은 진행 윈도우는 부위 윈도우의 오른편, 부위 윈도우는 진행 윈도우의 왼편으로 설정한 정도에서 넘어가야할 듯 합니다...
- 지난 PR에서 남겼던 윈도우 최대 크기 관련해서 추가적인 트러블이 있었습니다. [관련 내용](https://illustrious-fifth-36f.notion.site/visionOS-bc754cdf0bbc43cdb9f94810739bde14?pvs=4) ~~너무 힘들어요~~

# 스크린샷 (선택)
![Simulator Screen Recording - Apple Vision Pro - 2024-10-30 at 19 41 41](https://github.com/user-attachments/assets/067aa52f-f980-4237-814b-7209bf285fe5)