### PR TITLE
포물선 계산해서 엔터티 배치하기

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Shoulder/HandModelEnity.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/HandModelEnity.swift
@@ -1,0 +1,43 @@
+//
+//  HandModelEnity.swift
+//  APPRO
+//
+//  Created by Damin on 10/31/24.
+//
+
+import RealityKit
+import RealityKitContent
+
+struct HandModelEntity {
+    let thumbIntermediateBaseModelEntity: ModelEntity
+    let indexFingerTipModelEntity: ModelEntity
+    let rocketEntity: ModelEntity
+    
+    init() {
+        var clearMaterial = PhysicallyBasedMaterial()
+        clearMaterial.blending = .transparent(opacity: PhysicallyBasedMaterial.Opacity(scale: 0))
+        var fingerModelEntity = ModelEntity()
+        var markerModelEntity = ModelEntity()
+        
+        markerModelEntity = ModelEntity(mesh: .generateSphere(radius: 0.05), materials: [clearMaterial])
+        markerModelEntity.generateCollisionShapes(recursive: true)
+        markerModelEntity.name = "Marker"
+        
+        fingerModelEntity = ModelEntity(mesh: .generateBox(size: 0.012), materials: [clearMaterial])
+        fingerModelEntity.name = "Finger"
+        
+        self.thumbIntermediateBaseModelEntity = fingerModelEntity
+        self.indexFingerTipModelEntity = fingerModelEntity
+        self.rocketEntity = markerModelEntity
+        
+        setupRocketEntity()
+    }
+    
+    private func setupRocketEntity() {
+        Task {
+            if let rootEntity = try? await Entity(named: "Shoulder/RocketScene.usda", in: realityKitContentBundle) {
+                await rocketEntity.addChild(rootEntity)
+            }
+        }
+    }
+}

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -21,7 +21,6 @@ struct ShoulderStretchingView: View {
         .upperLimbVisibility(.hidden)
         .ignoresSafeArea()
         .onAppear() {
-            viewModel.setupRocketEntity()
             viewModel.addRightHandAnchor()
         }
         .task {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
@@ -127,8 +127,7 @@ extension ShoulderStretchingViewModel {
             
             if !isFistShowing {
                 resetModelEntities()
-                
-                // TODO: RightTransform 위치를 기준으로 포물선 생성
+                createEntitiesOnEllipticalArc(handTransform: self.rightHandTransform)
                 isFistShowing = true
             }
         }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
@@ -70,7 +70,7 @@ extension ShoulderStretchingViewModel {
             
             if !isFirstPositioning && !isFistShowing{
                 resetModelEntities()
-                // TODO: RightTransform 위치를 기준으로 포물선 생성
+                createEntitiesOnEllipticalArc(handTransform: self.rightHandTransform)
                 isFistShowing = true
                 return
             }
@@ -105,7 +105,7 @@ extension ShoulderStretchingViewModel {
                 )
                 self.rightHandTransform = Transform(matrix: mulitypliedMatrix)
                 
-                // TODO: RightTransform 위치를 기준으로 포물선 생성
+                createEntitiesOnEllipticalArc(handTransform: self.rightHandTransform)
                 isFistShowing = true
             } else {
                 return

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -22,13 +22,13 @@ final class ShoulderStretchingViewModel {
     var handTrackingProvider = HandTrackingProvider()
     var latestHandTracking: HandsUpdates = .init(left: nil, right: nil)
     // right
-    var rightThumbIntermediateBaseModelEntity = ModelEntity.createHandEntity()
-    var rightIndexFingerTipModelEntity = ModelEntity.createHandEntity()
-    var rightRocketEntity = ModelEntity.createHandEntity(isMarker: true)
+    var rightThumbIntermediateBaseModelEntity = ModelEntity()
+    var rightIndexFingerTipModelEntity = ModelEntity()
+    var rightRocketEntity = ModelEntity()
     // left
-    var leftIndexFingerIntermediateBaseModelEntity = ModelEntity.createHandEntity()
-    var leftIndexFingerTipModelEntity = ModelEntity.createHandEntity()
-    var leftRocketEntity = ModelEntity.createHandEntity(isMarker: true)
+    var leftIndexFingerIntermediateBaseModelEntity = ModelEntity()
+    var leftIndexFingerTipModelEntity = ModelEntity()
+    var leftRocketEntity = ModelEntity()
     
     var isFistShowing: Bool = false
     var isFirstPositioning: Bool = true
@@ -36,7 +36,30 @@ final class ShoulderStretchingViewModel {
     var rightHandTransform = Transform()
     private(set) var numberOfObjects: Int = 8
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
-
+    
+    init() {
+        rightThumbIntermediateBaseModelEntity = createHandEntity()
+        rightIndexFingerTipModelEntity = createHandEntity()
+        leftIndexFingerIntermediateBaseModelEntity = createHandEntity()
+        leftIndexFingerTipModelEntity = createHandEntity()
+        rightRocketEntity = createHandEntity(isMarker: true)
+        leftRocketEntity = createHandEntity(isMarker: true)
+    }
+    
+    private func createHandEntity(isMarker: Bool = false)  -> ModelEntity {
+        var modelEntity = ModelEntity()
+        var clearMaterial = PhysicallyBasedMaterial()
+        clearMaterial.blending = .transparent(opacity: PhysicallyBasedMaterial.Opacity(scale: 0))
+        if isMarker {
+            modelEntity = ModelEntity(mesh: .generateSphere(radius: 0.05), materials: [clearMaterial])
+            modelEntity.generateCollisionShapes(recursive: true)
+            modelEntity.name = "Marker"
+        } else {
+            modelEntity = ModelEntity(mesh: .generateBox(size: 0.012), materials: [clearMaterial])
+            modelEntity.name = "Finger"
+        }
+        return modelEntity
+    }
     
     func resetModelEntities() {
         modelEntities.forEach { entity in
@@ -181,21 +204,4 @@ final class ShoulderStretchingViewModel {
         }
     }
     
-}
-
-private extension ModelEntity {
-    static func createHandEntity(isMarker: Bool = false)  -> ModelEntity {
-        var modelEntity = ModelEntity()
-        var clearMaterial = PhysicallyBasedMaterial()
-        clearMaterial.blending = .transparent(opacity: PhysicallyBasedMaterial.Opacity(scale: 0))
-        if isMarker {
-            modelEntity = ModelEntity(mesh: .generateSphere(radius: 0.05), materials: [clearMaterial])
-            modelEntity.generateCollisionShapes(recursive: true)
-            modelEntity.name = "Marker"
-        } else {
-            modelEntity = ModelEntity(mesh: .generateBox(size: 0.012), materials: [clearMaterial])
-            modelEntity.name = "Finger"
-        }
-        return modelEntity
-    }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -88,8 +88,6 @@ final class ShoulderStretchingViewModel {
             Task {
                 if let starEntity = try? await Entity(named: "Shoulder/StarScene.usda", in: realityKitContentBundle) {
                     guard let starModelEntity = starEntity.findEntity(named: "Star") as? ModelEntity else { return }
-                    starModelEntity.name = "\(entityName)-\(idx)"
-                    starModelEntity.generateCollisionShapes(recursive: false)
                     
                     //TODO: 에셋자체를 회색으로 바꾸거나 UIColor로 디자인 색상 지정
                     let material = SimpleMaterial(color: .gray, isMetallic: false)
@@ -99,7 +97,8 @@ final class ShoulderStretchingViewModel {
                     }
                     let modelComponent = ModelComponent(mesh: mesh, materials: [material])
                     starModelEntity.components.set(modelComponent)
-                    
+
+                    starModelEntity.generateCollisionShapes(recursive: false)
                     starModelEntity.name = "\(entityName)-\(idx)"
                     starModelEntity.position = point
                     starModelEntity.scale = SIMD3<Float>(repeating: 0.001)

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -143,6 +143,44 @@ final class ShoulderStretchingViewModel {
         }
     }
     
+    func createEntitiesOnEllipticalArc(handTransform: Transform) {
+        // 손의 현재 위치를 파라미터로 받아서 어깨 기준으로 포물선을 계산 + 오른손보다 조금 옆으로 이동
+        let rightHandTranslation = SIMD3<Float>(x: handTransform.translation.x + 0.05, y: handTransform.translation.y, z: handTransform.translation.z)
+        // 원점과 handTranslation의 x축 차이에 따라 oppositeHandTranslation을 계산
+        let leftHandTranslation = simd_float3(-rightHandTranslation.x, rightHandTranslation.y, rightHandTranslation.z)
+        
+        // 어깨 중심 위치 (어깨는 손의 위치에 맞추어 설정)
+        let rightShoulderPosition = simd_float3(rightHandTranslation.x, rightHandTranslation.y, 0.0)
+        let leftShoulderPosition = simd_float3(-rightShoulderPosition.x, rightHandTranslation.y, 0.0)
+        
+        // 손이 원점 기준으로 오른쪽에 있는지 왼쪽에 있는지에 따라 isRightSide를 결정
+//        let isRightSide = handTranslation.x > 0
+        
+        if !isRightDone {
+            // 오른쪽 손에 대한 포물선 경로 계산 (150도)
+            let rightPoints = generateUniformEllipseArcPoints(
+                centerPosition: rightShoulderPosition,
+                numPoints: numberOfObjects,
+                startPoint: rightHandTranslation,  // 오른쪽 손의 위치를 시작점으로 설정
+                arcSpan: 150.0,
+                isRightSide: true
+            )
+            
+            addModelsToPoints(isRightSide: true, points: rightPoints)
+        } else {
+            // 왼쪽 손에 대한 포물선 경로 계산 (150도)
+            let leftPoints = generateUniformEllipseArcPoints(
+                centerPosition: leftShoulderPosition,  // 반대쪽 어깨 기준 위치
+                numPoints: numberOfObjects,
+                startPoint: leftHandTranslation,  // 반대쪽 손의 위치를 시작점으로 설정
+                arcSpan: 150.0,
+                isRightSide: false  // 왼손과 오른손 구분
+            )
+                        
+            addModelsToPoints(isRightSide: false, points: leftPoints)
+        }
+    }
+    
 }
 
 private extension ModelEntity {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -21,14 +21,8 @@ final class ShoulderStretchingViewModel {
     let session = ARKitSession()
     var handTrackingProvider = HandTrackingProvider()
     var latestHandTracking: HandsUpdates = .init(left: nil, right: nil)
-    // right
-    var rightThumbIntermediateBaseModelEntity = ModelEntity()
-    var rightIndexFingerTipModelEntity = ModelEntity()
-    var rightRocketEntity = ModelEntity()
-    // left
-    var leftIndexFingerIntermediateBaseModelEntity = ModelEntity()
-    var leftIndexFingerTipModelEntity = ModelEntity()
-    var leftRocketEntity = ModelEntity()
+    let rightHandModelEntity = HandModelEntity()
+    let leftHandModelEntity = HandModelEntity()
     
     var isFistShowing: Bool = false
     var isFirstPositioning: Bool = true
@@ -37,48 +31,13 @@ final class ShoulderStretchingViewModel {
     private(set) var numberOfObjects: Int = 8
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
     
-    init() {
-        rightThumbIntermediateBaseModelEntity = createHandEntity()
-        rightIndexFingerTipModelEntity = createHandEntity()
-        leftIndexFingerIntermediateBaseModelEntity = createHandEntity()
-        leftIndexFingerTipModelEntity = createHandEntity()
-        rightRocketEntity = createHandEntity(isMarker: true)
-        leftRocketEntity = createHandEntity(isMarker: true)
-    }
     
-    private func createHandEntity(isMarker: Bool = false)  -> ModelEntity {
-        var modelEntity = ModelEntity()
-        var clearMaterial = PhysicallyBasedMaterial()
-        clearMaterial.blending = .transparent(opacity: PhysicallyBasedMaterial.Opacity(scale: 0))
-        if isMarker {
-            modelEntity = ModelEntity(mesh: .generateSphere(radius: 0.05), materials: [clearMaterial])
-            modelEntity.generateCollisionShapes(recursive: true)
-            modelEntity.name = "Marker"
-        } else {
-            modelEntity = ModelEntity(mesh: .generateBox(size: 0.012), materials: [clearMaterial])
-            modelEntity.name = "Finger"
-        }
-        return modelEntity
-    }
     
     func resetModelEntities() {
         modelEntities.forEach { entity in
             entity.removeFromParent()
         }
         modelEntities = []
-    }
-    
-    func setupRocketEntity()  {
-        Task {
-            if let rootEntity = try? await Entity(named: "Shoulder/RocketScene.usda", in: realityKitContentBundle) {
-                rightRocketEntity.generateCollisionShapes(recursive: true)
-                rightRocketEntity.addChild(rootEntity)
-                
-                let leftRootEntity = rootEntity.clone(recursive: true)
-                leftRocketEntity.generateCollisionShapes(recursive: true)
-                leftRocketEntity.addChild(leftRootEntity)
-            }
-        }
     }
     
     // 어깨 중심을 기준으로 포물선 경로의 좌표를 생성하는 함수

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -30,10 +30,10 @@ final class ShoulderStretchingViewModel {
     var leftIndexFingerTipModelEntity = ModelEntity.createHandEntity()
     var leftRocketEntity = ModelEntity.createHandEntity(isMarker: true)
     
-    private var isFistShowing: Bool = false
-    private var isFirstPositioning: Bool = true
-    private var isRightDone: Bool = false
-    private var rightHandTransform = Transform()
+    var isFistShowing: Bool = false
+    var isFirstPositioning: Bool = true
+    var isRightDone: Bool = false
+    var rightHandTransform = Transform()
     private(set) var numberOfObjects: Int = 8
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
 

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -55,6 +55,47 @@ final class ShoulderStretchingViewModel {
         }
     }
     
+    // 어깨 중심을 기준으로 포물선 경로의 좌표를 생성하는 함수
+    func generateUniformEllipseArcPoints(
+        centerPosition: SIMD3<Float>,
+        numPoints: Int,
+        startPoint: SIMD3<Float>,  // 손의 위치를 시작점으로 받음
+        arcSpan: Float,
+        isRightSide: Bool
+    ) -> [SIMD3<Float>] {
+        var points: [SIMD3<Float>] = []
+        
+        let b: Float = abs(centerPosition.z - startPoint.z) // 타원의 단축 반지름
+        let a: Float = b * 1.5  // 타원의 장축 반지름
+        let y: Float = centerPosition.y  // Y 좌표는 어깨의 Y 좌표로 설정
+
+        // startPoint와 centerPosition 사이의 벡터를 이용하여 startAngle 계산
+        let deltaX = startPoint.x - centerPosition.x
+        let deltaZ = startPoint.z - centerPosition.z
+        // atan2를 사용하여 X, Z 평면에서의 각도(라디안)를 계산
+        let startAngle = atan2(deltaZ, deltaX)  // 각도는 Z축을 기준으로 계산됨
+        // 전체 호 길이를 라디안으로 변환
+        let totalArcLength: Float = arcSpan * (.pi / 180)
+
+        // 포인트 사이의 각도 계산 (각도를 균등하게 나누기)
+        let angleStep = totalArcLength / Float(numPoints - 1)
+
+        for i in 0..<numPoints {
+            // 각도를 계산 (시계 또는 반시계 방향으로 회전)
+            let angle = startAngle + (Float(i) * angleStep * (isRightSide ? 1 : -1))
+
+            // 각도에 따라 x, z 좌표 계산
+            let x = a * cos(angle)  // X축 대칭 (오른쪽은 양수, 왼쪽은 음수)
+            let z = b * sin(angle)  // Z축 방향 (양수는 +Z, 음수는 -Z로 이동)
+
+            // 최종 좌표 계산: 중심(centerPosition)을 기준으로 회전 적용
+            let point = SIMD3<Float>(x + centerPosition.x, y, z + centerPosition.z)
+            points.append(point)
+        }
+
+        return points
+    }
+    
 }
 
 private extension ModelEntity {


### PR DESCRIPTION
# 이슈
- close #20 
# 작업 사항
### 포물선 그리는 메서드 구조
- `generateUniformEllipseArcPoints` 메서드 구현
  - centerPosition은 포물선의 중심, starPosition은 포인트의 시작점, arcSpan은 포물선이 그려지는 각도
  - startAngle을 원점을 기준으로 손위치의 z축으로 벌어진 각도로 계산해서 그 각에서부터 그려지도록 함
- `addModelsToPoints` 메서드 구현
 - 파라미터로 받은 point에 RCP에서 불러온 StarEntity의 transform을 설정해서 contentEntity에 추가
  - 마지막 모델을 배치시, 그 위치와 회전을 약간수정하여 lastStarEntityTransform에 저장
- `createEntitiesOnEllipticalArc`
  - 파라미터로 받은 handTransForm의 오른손의 위치로 설정하고, -x 값으로 왼손의 위치를 설정 그에 따라 포물선의 축이되는 좌우 어깨의 position을 계산
  - 이 값들을 isRightDone에 따라 generateUniformEllipseArcPoints로 points를 받아와서 그 points로  addModelsToPoints 실행
### 코드리뷰 반영
- 기존에 ViewModel에서 각각 초기화 하였던 Hand Tracking 관련 변수를 HandModelEnitty 구조체를 만들어 그 내부 프로퍼티로 사용할 수 있게 하였습니다.

# 고민 or 참고 사항 (선택)
이전 PR에 남겼던 enum으로 분기처리를 하는것은 좀 더 고민해보고 반영해보겠습니다.
이번 PR에서도 개선할 점 있다면 피드백 남겨주세요.

# 스크린샷 (선택)