### PR TITLE
충돌 감지 및 이벤트 처리

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -50,7 +50,7 @@ struct ShoulderStretchingView: View {
             viewModel.resetExpectedNextNumber()
             // 충돌 상태가 유지되고 있는지 확인하기 위해 타이머를 설정
             if !viewModel.isColliding {
-                viewModel.toggleIsColliding()
+                viewModel.isColliding = true
                 viewModel.addShoulderTimerEntity()
             }
         }
@@ -69,6 +69,17 @@ struct ShoulderStretchingView: View {
         } else {
             viewModel.isRightDone = false
             viewModel.addRightHandAnchor()
+        }
+    }
+    
+    // 충돌 종료를 감지하여 타이머를 중지
+    func handleCollisionEnd(collisionEvent: CollisionEvents.Ended) {
+        let entityName = collisionEvent.entityB.name
+        
+        // 마지막 충돌 엔터티가 아닌 경우 또는 충돌이 끝났을 경우 타이머 중지
+        if entityName.contains("\(viewModel.numberOfObjects - 1)") {
+            viewModel.shoulderTimerEntity.removeFromParent()
+            viewModel.isColliding = false
         }
     }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -30,6 +30,31 @@ struct ShoulderStretchingView: View {
             await viewModel.updateHandTracking()
         }
     }
+    
+    func setCollisionAction(collisionEvent: CollisionEvents.Began, isRight: Bool) {
+        let entityName = isRight ? "rightModelEntity" : "leftModelEntity"
+        let collidedModelEntity = collisionEvent.entityB
+        // 충돌시 particle, audio 실행
+        viewModel.playEmitter(eventEntity: collidedModelEntity)
+        Task {
+            await viewModel.playSpatialAudio(collidedModelEntity)
+        }
+        // 다음 엔터티 일때만 Material 변경
+        if collidedModelEntity.name == "\(entityName)-\(viewModel.expectedNextNumber)" {
+            viewModel.changeMatreialColor(entity: collidedModelEntity)
+            viewModel.addExpectedNextNumber()
+        }
+        
+        // 마지막 엔터티 감지
+        if collidedModelEntity.name.contains("\(viewModel.numberOfObjects - 1)") {
+            viewModel.resetExpectedNextNumber()
+            // 충돌 상태가 유지되고 있는지 확인하기 위해 타이머를 설정
+            if !viewModel.isColliding {
+                viewModel.toggleIsColliding()
+                viewModel.addShoulderTimerEntity()
+            }
+        }
+    }
 }
 
 #Preview {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -14,7 +14,7 @@ struct ShoulderStretchingView: View {
     var body: some View {
         RealityView { content in
             content.add(viewModel.contentEntity)
-            //TODO: 충돌 이벤트 구독 액션 호출
+            subscribeToCollisionEvents(content: content)
         } update: { content in
             viewModel.computeTransformHandTracking()
         }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -55,6 +55,22 @@ struct ShoulderStretchingView: View {
             }
         }
     }
+    
+    // 충돌 상태가 5초 지속된 후 실행할 함수
+    func executeCollisionAction() {
+        // 충돌이 5초간 유지된 후 실행할 코드
+        viewModel.resetHandEntities()
+        viewModel.isFistShowing = false
+        viewModel.isFirstPositioning = false
+        
+        if !viewModel.isRightDone {
+            viewModel.isRightDone = true
+            viewModel.addLeftHandAnchor()
+        } else {
+            viewModel.isRightDone = false
+            viewModel.addRightHandAnchor()
+        }
+    }
 }
 
 #Preview {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -31,6 +31,32 @@ struct ShoulderStretchingView: View {
         }
     }
     
+    func subscribeToCollisionEvents(content: RealityViewContent) {
+        // 충돌 시작 감지
+        _ = content.subscribe(to: CollisionEvents.Began.self, on: viewModel.rightHandModelEntity.rocketEntity) { collisionEvent in
+            setCollisionAction(collisionEvent: collisionEvent, isRight: true)
+        }
+        
+        _ = content.subscribe(to: CollisionEvents.Began.self, on: viewModel.leftHandModelEntity.rocketEntity) { collisionEvent in
+            setCollisionAction(collisionEvent: collisionEvent, isRight: false)
+        }
+        
+        // 충돌 종료 감지
+        _ = content.subscribe(to: CollisionEvents.Ended.self, on: viewModel.rightHandModelEntity.rocketEntity) { collisionEvent in
+            handleCollisionEnd(collisionEvent: collisionEvent)
+        }
+        
+        _ = content.subscribe(to: CollisionEvents.Ended.self, on: viewModel.leftHandModelEntity.rocketEntity) { collisionEvent in
+            handleCollisionEnd(collisionEvent: collisionEvent)
+        }
+        
+        // 애니메이션 종료 감지
+        _ = content.subscribe(to: AnimationEvents.PlaybackCompleted.self, on: nil) { animationEvent in
+            animationEvent.playbackController.entity?.removeFromParent()
+            executeCollisionAction()
+        }
+    }
+    
     func setCollisionAction(collisionEvent: CollisionEvents.Began, isRight: Bool) {
         let entityName = isRight ? "rightModelEntity" : "leftModelEntity"
         let collidedModelEntity = collisionEvent.entityB
@@ -59,6 +85,7 @@ struct ShoulderStretchingView: View {
     // 충돌 상태가 5초 지속된 후 실행할 함수
     func executeCollisionAction() {
         // 충돌이 5초간 유지된 후 실행할 코드
+        viewModel.isColliding = false
         viewModel.resetHandEntities()
         viewModel.isFistShowing = false
         viewModel.isFirstPositioning = false

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
@@ -83,6 +83,7 @@ extension ShoulderStretchingViewModel {
                 isFistShowing = false
             } else if !isFistShowing && fingersDistance < 0.05 {
                 resetModelEntities()
+                resetExpectedNextNumber()
                 guard
                     let fistJoint = rightHandAnchor.handSkeleton?.joint(.middleFingerMetacarpal),
                     fistJoint.isTracked else {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -31,8 +31,6 @@ final class ShoulderStretchingViewModel {
     private(set) var numberOfObjects: Int = 8
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
     
-    
-    
     func resetModelEntities() {
         modelEntities.forEach { entity in
             entity.removeFromParent()
@@ -159,6 +157,13 @@ final class ShoulderStretchingViewModel {
             )
                         
             addModelsToPoints(isRightSide: false, points: leftPoints)
+        }
+    }
+    
+    func playAnimation(animationEntity: Entity) {
+        for animation in animationEntity.availableAnimations {
+            let animation = animation.repeat(count: 1)
+            let controller = animationEntity.playAnimation(animation, transitionDuration: 0.0, startsPaused: false)
         }
     }
     

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -180,4 +180,17 @@ final class ShoulderStretchingViewModel {
         eventEntity.components.set([particleEmitterComponent])
     }
     
+    func playSpatialAudio(_ entity: Entity) async {
+        guard let audioEntity = entity.findEntity(named: "SpatialAudio"), let indexString = entity.name.split(separator: "-").last, let idx = Int(indexString) else { return }
+        guard let resource = try? await AudioFileResource(named: "/Root/StarAudio_\((idx % 5) + 1)_wav",
+                                                          from: "Shoulder/StarScene.usda",
+                                                          in: realityKitContentBundle) else {
+            debugPrint("audio not found")
+            return
+        }
+        
+        let audioPlayer = audioEntity.prepareAudio(resource)
+        audioPlayer.play()
+    }
+    
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -38,6 +38,13 @@ final class ShoulderStretchingViewModel {
         modelEntities = []
     }
     
+    func resetHandEntities() {
+        handEntities.forEach { entity in
+            entity.removeFromParent()
+        }
+        handEntities = []
+    }
+    
     // 어깨 중심을 기준으로 포물선 경로의 좌표를 생성하는 함수
     func generateUniformEllipseArcPoints(
         centerPosition: SIMD3<Float>,

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -167,4 +167,17 @@ final class ShoulderStretchingViewModel {
         }
     }
     
+    func playEmitter(eventEntity: Entity) {
+        guard let particleEntity = eventEntity.findEntity(named: "ParticleEmitter"), var particleEmitterComponent = particleEntity.components[ParticleEmitterComponent.self] else {
+            debugPrint("particle Emitter component not found")
+            return
+        }
+        eventEntity.components.remove(ParticleEmitterComponent.self)
+        particleEmitterComponent.isEmitting = true
+        particleEmitterComponent.simulationState = .stop
+        particleEmitterComponent.simulationState = .play
+        
+        eventEntity.components.set([particleEmitterComponent])
+    }
+    
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -31,6 +31,20 @@ final class ShoulderStretchingViewModel {
     private(set) var numberOfObjects: Int = 8
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
     var shoulderTimerEntity = Entity()
+    private(set) var expectedNextNumber = 0
+    private(set) var isColliding = false
+    
+    func toggleIsColliding() {
+        isColliding.toggle()
+    }
+    
+    func resetExpectedNextNumber() {
+        expectedNextNumber = 0
+    }
+    
+    func addExpectedNextNumber() {
+        expectedNextNumber += 1
+    }
     
     func resetModelEntities() {
         modelEntities.forEach { entity in

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -34,6 +34,11 @@ final class ShoulderStretchingViewModel {
     private(set) var expectedNextNumber = 0
     var isColliding = false
     
+    deinit {
+        dump("\(self) deinited")
+        session.stop()
+    }
+    
     func resetExpectedNextNumber() {
         expectedNextNumber = 0
     }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -193,4 +193,20 @@ final class ShoulderStretchingViewModel {
         audioPlayer.play()
     }
     
+    func changeMatreialColor(entity: Entity) {
+        guard let modelEntity = entity as? ModelEntity else {
+            debugPrint("not a model entity")
+            return
+        }
+        
+        // TODO: 불켜진 Star 모델 색상 변경
+        let newMeterial = SimpleMaterial(color: .yellow, isMetallic: false)
+        guard let mesh = modelEntity.components[ModelComponent.self]?.mesh else {
+            debugPrint("no mesh found")
+            return
+        }
+         
+        let modelComponent = ModelComponent(mesh: mesh, materials: [newMeterial])
+        modelEntity.components.set(modelComponent)
+    }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -32,11 +32,7 @@ final class ShoulderStretchingViewModel {
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
     var shoulderTimerEntity = Entity()
     private(set) var expectedNextNumber = 0
-    private(set) var isColliding = false
-    
-    func toggleIsColliding() {
-        isColliding.toggle()
-    }
+    var isColliding = false
     
     func resetExpectedNextNumber() {
         expectedNextNumber = 0

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -30,6 +30,7 @@ final class ShoulderStretchingViewModel {
     var rightHandTransform = Transform()
     private(set) var numberOfObjects: Int = 8
     private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
+    var shoulderTimerEntity = Entity()
     
     func resetModelEntities() {
         modelEntities.forEach { entity in
@@ -215,5 +216,18 @@ final class ShoulderStretchingViewModel {
          
         let modelComponent = ModelComponent(mesh: mesh, materials: [newMeterial])
         modelEntity.components.set(modelComponent)
+    }
+    
+    func addShoulderTimerEntity() {
+        Task {
+            if let rootEntity = try? await Entity(named: "Shoulder/ShoulderTimerScene.usda", in: realityKitContentBundle) {
+                shoulderTimerEntity.name = "ShoulderTimerEntity"
+                shoulderTimerEntity = rootEntity
+                shoulderTimerEntity.transform = lastStarEntityTransform
+                shoulderTimerEntity.scale *= 2
+                contentEntity.addChild(shoulderTimerEntity)
+                playAnimation(animationEntity: shoulderTimerEntity)
+            }
+        }
     }
 }


### PR DESCRIPTION
# 이슈
- close #22 
# 작업 사항
- ViewModel 에 아래와 같은 작업 실행 메서드 추가
  - 애니메이션 실행
  - 파티클 에미터 실행
    - RCP에서 에미터 엔터티의 isEmitting, isLooping을 false로 설정해서 엔터티가 띄워졌을때 실행이 안되게 설정 해놓고
    - playEmitter 메서드 실행시 해당 엔터티의 ParticleEmitterComponent를 가져와서 엔터티에서 기존에 있던 컴포넌트를 삭제하고 isEmitting을 true로 바꾸고 simulationState를 stop, play로 설정해서 다시 ParticleEmitterComponent로 세팅해준다. (이렇게 기존거를 삭제하고 다시 넣어야지 제대로 적용이 됨)
  - 오디오 실행
    - StarModelEntity를 배치할때 지정한 엔터티 이름의 인덱스를 이용해 같은 순서의 소리 파일을 로드하여 재생
  - 메테리얼 색상 변경
    - 파라미터로 받은 엔터티에 새로 만든 material을 다른 색으로 지정하여 다시 적용하여 material 색상 변경

- View에서는 content를 이용해 충돌 이벤트들을 구독하는 로직을 추가하였습니다.
  - 손 위에 띄워지는 RocketEntity에 충돌되는 엔터티에 감지를 받아서 그에 따른 액션들을 설정해줬습니다.

# 고민 or 참고 사항 (선택)

현재 뷰모델에 isColliding이라는 변수를 두어 손하고 별 모델이 충돌중인지 아닌지 판별하려고 하는데, 뷰에 변수를 두면 보라색 쓰레드 워닝이 떠서 뷰모델로 옮긴건데, 뷰모델에 있는 Bool 값이라 private으로 설정하지 못한게 아쉽습니다. Bool 값을 private으로 두고 뷰모델에 isColliding을 변경하는 메서드를 둘까도 생각해봤지만 굳이인 느낌이 들어 우선은 이렇게 public Bool 값으로 설정한 상태인데 이를 어떻게 관리하는게 좋을지 고민입니다. 

아니면 뷰에 있는 충돌 관련 로직도 아예 다 viewModel로 옮기는게 나을지 피드백 부탁드려요

다른 코드에 대한 피드백도 환영입니다.

# 스크린샷 (선택)
