### PR TITLE
튜토리얼 윈도우 구현

### DIFF
--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -25,11 +25,6 @@ struct APPROApp: App {
         }
         .windowStyle(.plain)
         .windowResizability(.contentSize)
-        .defaultWindowPlacement { content, context in
-            guard let stretchingProcessWindow = context.windows.first(where: { $0.id == appState.stretchingProcessWindowID }) else { return .init(.none) }
-            
-            return .init(.leading(stretchingProcessWindow))
-        }
         .onChange(of: appState.appPhase) { _, newPhase in
             switch newPhase {
             case .choosingStretchingPart:
@@ -46,12 +41,20 @@ struct APPROApp: App {
             }
         }
         .windowStyle(.plain)
-        .defaultWindowPlacement { _, context in
-            guard let stretchingPartsWindow = context.windows.first(where: { $0.id == appState.stretchingPartsWindowID }) else { return .init(.none) }
-            
-            return .init(.trailing(stretchingPartsWindow))
-        }
         .windowResizability(.contentSize)
+        .defaultWindowPlacement { _, _ in
+            return WindowPlacement(.utilityPanel)
+        }
+        
+        WindowGroup(id: appState.stretchingTutorialWindowID) {
+            TutorialView()
+                .environment(appState)
+        }
+        .windowStyle(.plain)
+        .windowResizability(.contentSize)
+        .defaultWindowPlacement { _, _ in
+            return WindowPlacement(.utilityPanel)
+        }
         
         ImmersiveSpace(id: appState.immersiveSpaceID) {
             // TODO: 각 스트레칭에 따른 뷰 추가

--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -22,6 +22,10 @@ struct APPROApp: App {
         WindowGroup(id: appState.stretchingPartsWindowID) {
             StretchingPartsView()
                 .environment(appState)
+                .onAppear {
+                    dismissWindow(id: appState.stretchingTutorialWindowID)
+                    dismissWindow(id: appState.stretchingProcessWindowID)
+                }
         }
         .windowStyle(.plain)
         .windowResizability(.contentSize)
@@ -54,6 +58,10 @@ struct APPROApp: App {
         WindowGroup(id: appState.stretchingProcessWindowID) {
             StretchingProcessView()
                 .environment(appState)
+                .onAppear {
+                    dismissWindow(id: appState.stretchingPartsWindowID)
+                    dismissWindow(id: appState.stretchingProcessWindowID)
+                }
         }
         .windowStyle(.plain)
         .windowResizability(.contentSize)
@@ -64,6 +72,9 @@ struct APPROApp: App {
         WindowGroup(id: appState.stretchingTutorialWindowID) {
             TutorialView()
                 .environment(appState)
+                .onAppear {
+                    dismissWindow(id: appState.stretchingPartsWindowID)
+                }
         }
         .windowStyle(.plain)
         .windowResizability(.contentSize)

--- a/APPRO/APPRO/Data & State/AppPhase.swift
+++ b/APPRO/APPRO/Data & State/AppPhase.swift
@@ -10,13 +10,14 @@ import Foundation
 enum AppPhase: Sendable, Equatable {
     
     case choosingStretchingPart
-    case isStretching(Stretching)
+    case tutorial
+    case stretching
     
     var isImmersed: Bool {
         switch self {
         case .choosingStretchingPart:
             return false
-        case .isStretching:
+        case .tutorial, .stretching:
             return true
         }
     }

--- a/APPRO/APPRO/Data & State/AppState.swift
+++ b/APPRO/APPRO/Data & State/AppState.swift
@@ -26,6 +26,8 @@ final class AppState {
         }
     }
     
+    var tutorialManager: TutorialManager? = nil
+    
     var doneCount = 0
     private(set) var maxCount = 0
     

--- a/APPRO/APPRO/Data & State/AppState.swift
+++ b/APPRO/APPRO/Data & State/AppState.swift
@@ -14,6 +14,7 @@ final class AppState {
     
     let stretchingPartsWindowID = "StretchingPartsWindow"
     let stretchingProcessWindowID = "StretchingProcessWindow"
+    let stretchingTutorialWindowID = "StretchingTutorialWindow"
     let immersiveSpaceID = "StretchingSpace"
     
     var appPhase: AppPhase = .choosingStretchingPart

--- a/APPRO/APPRO/Data & State/AppState.swift
+++ b/APPRO/APPRO/Data & State/AppState.swift
@@ -19,14 +19,7 @@ final class AppState {
     
     var appPhase: AppPhase = .choosingStretchingPart
     
-    var currentStretching: Stretching? {
-        if case .isStretching(let stretching) = appPhase {
-            return stretching
-        } else {
-            return nil
-        }
-    }
-    
+    var currentStretchingPart: StretchingPart? = nil
     var tutorialManager: TutorialManager? = nil
     
     var doneCount = 0

--- a/APPRO/APPRO/Data & State/AppState.swift
+++ b/APPRO/APPRO/Data & State/AppState.swift
@@ -26,7 +26,7 @@ final class AppState {
     private(set) var maxCount = 0
     
     func resetStretchingCount() {
-        if let stretching = currentStretching {
+        if let stretching = currentStretchingPart {
             doneCount = 0
             maxCount = (stretching == .eyes || stretching == .wrist) ? 12 : 3
         } else {

--- a/APPRO/APPRO/Model/StretchingPart.swift
+++ b/APPRO/APPRO/Model/StretchingPart.swift
@@ -5,7 +5,7 @@
 //  Created by 정상윤 on 10/13/24.
 //
 
-enum Stretching: String, Identifiable, CaseIterable {
+enum StretchingPart: String, Identifiable, CaseIterable {
     
     case eyes, wrist, shoulder
     

--- a/APPRO/APPRO/Model/TutorialManager.swift
+++ b/APPRO/APPRO/Model/TutorialManager.swift
@@ -11,8 +11,18 @@ import Foundation
 @Observable
 class TutorialManager {
     
+    let stretchingPart: StretchingPart
+    
     private(set) var steps: [TutorialStep] = []
     private var currentStepIndex = 0
+    
+    init(stretching: StretchingPart) {
+        self.stretchingPart = stretching
+    }
+    
+    var isSkipped: Bool {
+        UserDefaults.standard.bool(forKey: "\(stretchingPart)TutorialSkipped")
+    }
     
     var isCompleted: Bool {
         currentStepIndex >= steps.count
@@ -33,5 +43,21 @@ class TutorialManager {
     func skip() {
         currentStepIndex = steps.count
     }
+    
+}
+
+extension TutorialManager {
+    
+    static let sampleTutorialManager: TutorialManager = {
+        let manager = TutorialManager(stretching: .eyes)
+        
+        manager.initializeSteps([
+            .init(instruction: "This is step 1", isCompleted: { true }),
+            .init(instruction: "This is step 2", isCompleted: { true }),
+            .init(instruction: "This is step 3", isCompleted: { true })
+        ])
+        
+        return manager
+    }()
     
 }

--- a/APPRO/APPRO/Model/TutorialManager.swift
+++ b/APPRO/APPRO/Model/TutorialManager.swift
@@ -5,6 +5,10 @@
 //  Created by 정상윤 on 10/31/24.
 //
 
+import Foundation
+
+@MainActor
+@Observable
 class TutorialManager {
     
     private(set) var steps: [TutorialStep] = []

--- a/APPRO/APPRO/Model/TutorialManager.swift
+++ b/APPRO/APPRO/Model/TutorialManager.swift
@@ -15,13 +15,16 @@ class TutorialManager {
     
     private(set) var steps: [TutorialStep] = []
     private var currentStepIndex = 0
+    private var userDefulatsKey: String {
+        "\(stretchingPart)TutorialSkipped"
+    }
     
     init(stretching: StretchingPart) {
         self.stretchingPart = stretching
     }
     
     var isSkipped: Bool {
-        UserDefaults.standard.bool(forKey: "\(stretchingPart)TutorialSkipped")
+        UserDefaults.standard.bool(forKey: userDefulatsKey)
     }
     
     var isCompleted: Bool {
@@ -41,6 +44,7 @@ class TutorialManager {
     }
     
     func skip() {
+        UserDefaults.standard.setValue(true, forKey: userDefulatsKey)
         currentStepIndex = steps.count
     }
     

--- a/APPRO/APPRO/Views/StretchingParts/StretchingCard.swift
+++ b/APPRO/APPRO/Views/StretchingParts/StretchingCard.swift
@@ -16,6 +16,7 @@ struct StretchingCard: View {
     var body: some View {
         Button(action: {
             appState.appPhase = .tutorial
+            appState.currentStretchingPart = stretching
         }) {
             VStack {
                 Spacer()

--- a/APPRO/APPRO/Views/StretchingParts/StretchingCard.swift
+++ b/APPRO/APPRO/Views/StretchingParts/StretchingCard.swift
@@ -11,11 +11,11 @@ struct StretchingCard: View {
     
     @Environment(AppState.self) private var appState
     
-    let stretching: Stretching
+    let stretching: StretchingPart
     
     var body: some View {
         Button(action: {
-            appState.appPhase = .isStretching(stretching)
+            appState.appPhase = .tutorial
         }) {
             VStack {
                 Spacer()

--- a/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/StretchingProcessView.swift
@@ -14,7 +14,7 @@ struct StretchingProcessView: View {
     @Environment(\.scenePhase) private var scenePhase
     
     var body: some View {
-        if let stretching = appState.currentStretching {
+        if let stretchingPart = appState.currentStretchingPart {
             VStack(spacing: 20) {
                 ZStack(alignment: .center) {
                     HStack {
@@ -25,11 +25,11 @@ struct StretchingProcessView: View {
                         
                         Spacer()
                     }
-                    Text("\(stretching.title) Stretch")
+                    Text("\(stretchingPart.title) Stretch")
                         .font(.largeTitle)
                 }
                 
-                if stretching == .eyes || stretching == .wrist {
+                if stretchingPart == .eyes || stretchingPart == .wrist {
                     Text("Score")
                         .font(.title)
                         .opacity(0.96)
@@ -71,7 +71,8 @@ struct StretchingProcessView: View {
 #Preview(windowStyle: .plain) {
     let appState = AppState()
     
-    appState.appPhase = .isStretching(.shoulder)
+    appState.appPhase = .stretching
+    appState.currentStretchingPart = .shoulder
     
     return StretchingProcessView()
         .environment(appState)

--- a/APPRO/APPRO/Views/Tutorial/TutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialView.swift
@@ -58,16 +58,8 @@ struct TutorialView: View {
 }
     
 #Preview(windowStyle: .plain) {
-    let sampleTutorial = TutorialManager()
     var appState = AppState()
-    
-    sampleTutorial.initializeSteps([
-        .init(instruction: "This is step 1", isCompleted: { true }),
-        .init(instruction: "This is step 2", isCompleted: { true }),
-        .init(instruction: "This is step 3", isCompleted: { true })
-    ])
-    appState.tutorialManager = sampleTutorial
-    
+    appState.tutorialManager = TutorialManager.sampleTutorialManager
     return TutorialView()
         .environment(appState)
 }

--- a/APPRO/APPRO/Views/Tutorial/TutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialView.swift
@@ -58,7 +58,7 @@ struct TutorialView: View {
 }
     
 #Preview(windowStyle: .plain) {
-    var appState = AppState()
+    let appState = AppState()
     appState.tutorialManager = TutorialManager.sampleTutorialManager
     return TutorialView()
         .environment(appState)

--- a/APPRO/APPRO/Views/Tutorial/TutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialView.swift
@@ -1,0 +1,73 @@
+//
+//  TutorialView.swift
+//  APPRO
+//
+//  Created by 정상윤 on 10/31/24.
+//
+
+import SwiftUI
+
+struct TutorialView: View {
+    
+    @Environment(AppState.self) private var appState
+    
+    @State private var showSkipAlert = false
+    
+    var body: some View {
+        if let tutorialManager = appState.tutorialManager,
+           !tutorialManager.isCompleted {
+            VStack(alignment: .trailing, spacing: 16) {
+                HStack {
+                    Text("Tutorial")
+                        .font(.extraLargeTitle2)
+                    Spacer()
+                    HStack(spacing: 16) {
+                        // TODO: Mute 버튼 추가
+                        Button("Skip Tutorial", systemImage: "forward.end") {
+                            showSkipAlert = true
+                        }
+                        .labelStyle(.iconOnly)
+                    }
+                }
+                Text(tutorialManager.currentStep.instruction)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.system(size: 32, weight: .medium))
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(3)
+                Spacer()
+                Button("Next") {
+                    tutorialManager.advanceToNextStep()
+                }
+                .font(.title3)
+                .disabled(!tutorialManager.currentStep.isCompleted())
+            }
+            .frame(width: 800, height: 300)
+            .padding(32)
+            .alert("Skip Tutorial", isPresented: $showSkipAlert) {
+                Button("Yes") {
+                    tutorialManager.skip()
+                }
+                Button("No", role: .cancel) {}
+            } message: {
+                Text("Start the content right away.\nNever show tutorial again.")
+            }
+            .glassBackgroundEffect()
+        }
+    }
+    
+}
+    
+#Preview(windowStyle: .plain) {
+    let sampleTutorial = TutorialManager()
+    var appState = AppState()
+    
+    sampleTutorial.initializeSteps([
+        .init(instruction: "This is step 1", isCompleted: { true }),
+        .init(instruction: "This is step 2", isCompleted: { true }),
+        .init(instruction: "This is step 3", isCompleted: { true })
+    ])
+    appState.tutorialManager = sampleTutorial
+    
+    return TutorialView()
+        .environment(appState)
+}


### PR DESCRIPTION
# 이슈
- close #18 

# 작업 사항
- TutorialView 구현
- WindowGroup 추가 및 기본 위치 설정
- AppPhase 관련 로직들 리팩토링

# 고민 or 참고 사항 (선택)
## AppPhase case문 수정

처음에 associated value를 가진 enum case를 활용했는데, 이게 은근 필요 없다는 생각이 들거나 코드 작성에 방해가 되거나 순간들이 있었습니다. 

예로 if문이 너무 길어진다는 점 `case .stretching(_) = appState.appPhase`, 그리고 뷰들이 따로 주입받는 것이 아니라 어차피 AppState 인스턴스의 프로퍼티에 접근하여 스트레칭 부위를 가져오면 돼서 그냥 간단하게 코드를 바꾸자라는 생각이 들어서 바꿨습니다.

## AppPhase 처리
튜토리얼 AppPhase가 추가됨에 따라 윈도우 구성 로직과 몰입 공간 열고 닫는 로직을 리팩토링했습니다. 

기존의 AppPhase의 case문에 따라 몰입 공간을 열고 닫던 로직은 몰입 공간을 열지 말지에 대해 처리하는 것이 까다로웠습니다. (몰입 공간이 열려있는 상태에서 또 호출되는 문제가 있는 등) 

따라서 AppPhase의 isImmersed 연산 프로퍼티를 통해 결정됩니다. 이를 통해 isImmersed의 값이 바뀌는 경우에만 몰입 공간의 열고 닫음이 결정되며 `openImmersiveSpace` / `dismissImmersiveSpace` 중복 호출을 방지할 수 있게 됩니다.

또한 열려있지 않은 윈도우에 대한 `dismissWindow` 호출에 아무런 문제가 없는 것을 확인했고, 각 뷰의 `onAppear`에서 나머지 `WindowGroup`들을 dismiss 하도록 구현했습니다.

## 튜토리얼

그리고 튜토리얼이 스킵됐는지의 여부를 확인하는 책임을 누구에게 줄 것인가에 대해 고민했고, 현재는 Skip 됐음을 `UserDefaults`에 저장하는 역할을 맡고 있는 TutorialManager에게 줬습니다. 

다만 인스턴스의 생성이 스킵 여부와 상관 없이 무조건 이뤄지는 점이 찝찝하긴 해서 나중에 리팩토링할 수 있는 부분인 것 같습니다.

# 스크린샷 (선택)
없음