### PR TITLE
어깨 엔트리 로켓 애니메이션 추가 및 리팩토링

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Shoulder/HandModelEnity.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/HandModelEnity.swift
@@ -11,34 +11,20 @@ import RealityKitContent
 struct HandModelEntity {
     let thumbIntermediateBaseModelEntity: ModelEntity
     let indexFingerTipModelEntity: ModelEntity
-    let rocketEntity: ModelEntity
 
     init() {
         var clearMaterial = PhysicallyBasedMaterial()
         clearMaterial.blending = .transparent(opacity: PhysicallyBasedMaterial.Opacity(floatLiteral: 0))
         var fingerModelEntity = ModelEntity()
-        var markerModelEntity = ModelEntity()
-        
-        markerModelEntity = ModelEntity(mesh: .generateSphere(radius: 1), materials: [clearMaterial])
-        markerModelEntity.generateCollisionShapes(recursive: true)
-        markerModelEntity.name = "Marker"
-        
+
+        let opacityComponent = OpacityComponent(opacity: 0)
+
         fingerModelEntity = ModelEntity(mesh: .generateBox(size: 0.012), materials: [clearMaterial])
+        fingerModelEntity.components.set(opacityComponent)
         fingerModelEntity.name = "Finger"
         
         self.thumbIntermediateBaseModelEntity = fingerModelEntity
         self.indexFingerTipModelEntity = fingerModelEntity
-        self.rocketEntity = markerModelEntity
-        setupRocketEntity()
     }
-    
-    private func setupRocketEntity() {
-        Task { @MainActor in
-            if let rootEntity = try? await Entity(named: "Shoulder/RocketScene.usda", in: realityKitContentBundle) {
-                rootEntity.scale *= 8.0
-                rootEntity.name = "RocketEntity"
-                rocketEntity.addChild(rootEntity)
-            }
-        }
-    }
+
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -15,6 +15,8 @@ struct ShoulderStretchingView: View {
     var body: some View {
         RealityView { content in
             content.add(viewModel.contentEntity)
+            await viewModel.setEntryRocket()
+            viewModel.setHandRocketEntity()
             subscribeToCollisionEvents(content: content)
         } update: { content in
             viewModel.computeTransformHandTracking()
@@ -22,7 +24,7 @@ struct ShoulderStretchingView: View {
         .upperLimbVisibility(.hidden)
         .ignoresSafeArea()
         .onAppear() {
-            viewModel.addRightHandAnchor()
+           
         }
         .task {
             await viewModel.startHandTrackingSession()

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -40,6 +40,7 @@ struct ShoulderStretchingView: View {
         
         _ = content.subscribe(to: CollisionEvents.Began.self, on: viewModel.leftHandModelEntity.rocketEntity) { collisionEvent in
             setCollisionAction(collisionEvent: collisionEvent, isRight: false)
+        guard let rightCollisionModel = viewModel.handRocketEntity.findEntity(named: "RocketCollisionModel") as? ModelEntity else { return }
         }
         
         // 충돌 종료 감지

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -33,22 +33,15 @@ struct ShoulderStretchingView: View {
     }
     
     func subscribeToCollisionEvents(content: RealityViewContent) {
-        // 충돌 시작 감지
-        _ = content.subscribe(to: CollisionEvents.Began.self, on: viewModel.rightHandModelEntity.rocketEntity) { collisionEvent in
-            setCollisionAction(collisionEvent: collisionEvent, isRight: true)
-        }
-        
-        _ = content.subscribe(to: CollisionEvents.Began.self, on: viewModel.leftHandModelEntity.rocketEntity) { collisionEvent in
-            setCollisionAction(collisionEvent: collisionEvent, isRight: false)
         guard let rightCollisionModel = viewModel.handRocketEntity.findEntity(named: "RocketCollisionModel") as? ModelEntity else { return }
+
+            // 충돌 시작 감지
+        _ = content.subscribe(to: CollisionEvents.Began.self, on: rightCollisionModel) { collisionEvent in
+            setCollisionAction(collisionEvent: collisionEvent)
         }
         
         // 충돌 종료 감지
-        _ = content.subscribe(to: CollisionEvents.Ended.self, on: viewModel.rightHandModelEntity.rocketEntity) { collisionEvent in
-            handleCollisionEnd(collisionEvent: collisionEvent)
-        }
-        
-        _ = content.subscribe(to: CollisionEvents.Ended.self, on: viewModel.leftHandModelEntity.rocketEntity) { collisionEvent in
+        _ = content.subscribe(to: CollisionEvents.Ended.self, on: rightCollisionModel) { collisionEvent in
             handleCollisionEnd(collisionEvent: collisionEvent)
         }
         

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -23,8 +23,8 @@ struct ShoulderStretchingView: View {
         }
         .upperLimbVisibility(.hidden)
         .ignoresSafeArea()
-        .onAppear() {
-           
+        .task {
+            await viewModel.loadStarModelEntity()
         }
         .task {
             await viewModel.startHandTrackingSession()

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -47,12 +47,17 @@ struct ShoulderStretchingView: View {
         
         // 애니메이션 종료 감지
         _ = content.subscribe(to: AnimationEvents.PlaybackCompleted.self, on: nil) { animationEvent in
-            animationEvent.playbackController.entity?.removeFromParent()
-            executeCollisionAction()
+            if animationEvent.playbackController.entity?.name == "EntryRocket" {
+                viewModel.entryRocketEntity.removeFromParent()
+                viewModel.addRightHandAnchor()
+            }else {
+                animationEvent.playbackController.entity?.removeFromParent()
+                executeCollisionAction()
+            }
         }
     }
     
-    func setCollisionAction(collisionEvent: CollisionEvents.Began, isRight: Bool) {
+    func setCollisionAction(collisionEvent: CollisionEvents.Began) {
         
         let collidedModelEntity = collisionEvent.entityB
         
@@ -62,7 +67,7 @@ struct ShoulderStretchingView: View {
             return
         }
         
-        let entityName = isRight ? "rightModelEntity" : "leftModelEntity"
+        let entityName = viewModel.isRightDone ? "leftModelEntity" : "rightModelEntity"
         
         // 충돌시 particle, audio 실행
         viewModel.playEmitter(eventEntity: collidedModelEntity)

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
@@ -48,10 +48,11 @@ extension ShoulderStretchingViewModel {
             }
             
             //right
-            rightHandModelEntity.thumbIntermediateBaseModelEntity.transform = getTransform(rightHandAnchor, .thumbIntermediateBase, rightHandModelEntity.thumbIntermediateBaseModelEntity.transform)
-            rightHandModelEntity.indexFingerTipModelEntity.transform = getTransform(rightHandAnchor, .indexFingerTip, rightHandModelEntity.indexFingerTipModelEntity.transform)
+            handModelEntity.thumbIntermediateBaseModelEntity.transform = getTransform(rightHandAnchor, .thumbIntermediateBase, handModelEntity.thumbIntermediateBaseModelEntity.transform)
+            handModelEntity.indexFingerTipModelEntity.transform = getTransform(rightHandAnchor, .indexFingerTip, handModelEntity.indexFingerTipModelEntity.transform)
             
-            rightHandModelEntity.rocketEntity.transform = getTransform(rightHandAnchor, .middleFingerMetacarpal, rightHandModelEntity.rocketEntity.transform)
+            handRocketEntity.transform = getTransform(rightHandAnchor, .middleFingerMetacarpal, handRocketEntity.transform)
+            
             
             if !isFirstPositioning {
                 //TODO: isFirstPositioning 이 false가 된 후에는 isFistShowing을 확인할 필요가 없음
@@ -107,10 +108,10 @@ extension ShoulderStretchingViewModel {
                 return
             }
             //left
-            leftHandModelEntity.thumbIntermediateBaseModelEntity.transform = getTransform(leftHandAnchor, .thumbIntermediateBase, leftHandModelEntity.thumbIntermediateBaseModelEntity.transform)
-            leftHandModelEntity.indexFingerTipModelEntity.transform = getTransform(leftHandAnchor, .indexFingerTip, leftHandModelEntity.indexFingerTipModelEntity.transform)
-            leftHandModelEntity.rocketEntity.transform = getTransform(leftHandAnchor, .middleFingerMetacarpal, leftHandModelEntity.rocketEntity.transform)
-            leftHandModelEntity.rocketEntity.transform.rotation *= simd_quatf(angle: .pi, axis: SIMD3<Float>(0, 1, 0))
+            handModelEntity.thumbIntermediateBaseModelEntity.transform = getTransform(leftHandAnchor, .thumbIntermediateBase, handModelEntity.thumbIntermediateBaseModelEntity.transform)
+            handModelEntity.indexFingerTipModelEntity.transform = getTransform(leftHandAnchor, .indexFingerTip, handModelEntity.indexFingerTipModelEntity.transform)
+            handRocketEntity.transform = getTransform(leftHandAnchor, .middleFingerMetacarpal, handRocketEntity.transform)
+            handRocketEntity.transform.rotation *= simd_quatf(angle: .pi, axis: SIMD3<Float>(0, 1, 0))
             
             
             if !isFistShowing {
@@ -139,9 +140,9 @@ extension ShoulderStretchingViewModel {
     
     func addRightHandAnchor() {
         let modelEntities = [
-            rightHandModelEntity.indexFingerTipModelEntity,
-            rightHandModelEntity.thumbIntermediateBaseModelEntity,
-            rightHandModelEntity.rocketEntity
+            handModelEntity.indexFingerTipModelEntity,
+            handModelEntity.thumbIntermediateBaseModelEntity,
+            handRocketEntity
         ]
         
         for entity in modelEntities {
@@ -152,9 +153,9 @@ extension ShoulderStretchingViewModel {
     
     func addLeftHandAnchor() {
         let modelEntities = [
-            leftHandModelEntity.indexFingerTipModelEntity,
-            leftHandModelEntity.thumbIntermediateBaseModelEntity,
-            leftHandModelEntity.rocketEntity
+            handModelEntity.indexFingerTipModelEntity,
+            handModelEntity.thumbIntermediateBaseModelEntity,
+            handRocketEntity
         ]
         
         for entity in modelEntities {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
@@ -93,7 +93,12 @@ extension ShoulderStretchingViewModel {
                     rightHandAnchor.originFromAnchorTransform, fistJoint.anchorFromJointTransform
                 )
                 self.rightHandTransform = Transform(matrix: mulitypliedMatrix)
-                
+                if !isEntryEnd {
+                    self.rightHandTransform.scale = .init(x: 0.1, y: 0.1, z: 0.1)
+                    playEntryRocketAnimation()
+                    isEntryEnd = true
+                    return
+                }
                 createEntitiesOnEllipticalArc(handTransform: self.rightHandTransform)
                 isFistShowing = true
             } else {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -288,6 +288,6 @@ final class ShoulderStretchingViewModel {
     
     func setHandRocketEntity() {
         handRocketEntity = entryRocketEntity.clone(recursive: true)
-        handRocketEntity.name = "rightHandRocket"
+        handRocketEntity.name = "handRocket"
     }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -266,4 +266,21 @@ final class ShoulderStretchingViewModel {
             contentEntity.addChild(entryRocketEntity)
         }
     }
+    
+    func playEntryRocketAnimation() {
+        let goInDirection = FromToByAnimation<Transform> (
+            name: "EntryRocket",
+            from: entryRocketTransForm,
+            to: rightHandTransform,
+            duration: 2,
+            bindTarget: .transform
+        )
+        
+        do {
+            let animation = try AnimationResource.generate(with: goInDirection)
+            entryRocketEntity.playAnimation(animation, transitionDuration: 2)
+        } catch {
+            debugPrint("Error generating animation: \(error)")
+        }
+    }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -283,4 +283,9 @@ final class ShoulderStretchingViewModel {
             debugPrint("Error generating animation: \(error)")
         }
     }
+    
+    func setHandRocketEntity() {
+        handRocketEntity = entryRocketEntity.clone(recursive: true)
+        handRocketEntity.name = "rightHandRocket"
+    }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -21,20 +21,26 @@ final class ShoulderStretchingViewModel {
     let session = ARKitSession()
     var handTrackingProvider = HandTrackingProvider()
     var latestHandTracking: HandsUpdates = .init(left: nil, right: nil)
-    let rightHandModelEntity = HandModelEntity()
-    let leftHandModelEntity = HandModelEntity()
+    let handModelEntity = HandModelEntity()
+    var entryRocketEntity = Entity()
+    var handRocketEntity = Entity()
+    var shoulderTimerEntity = Entity()
     
     var isFistShowing: Bool = false
     var isFirstPositioning: Bool = true
     var isRightDone: Bool = false
+    var isEntryEnd = false
+
     var rightHandTransform = Transform()
+    var entryRocketTransForm = Transform()
+    private var shoulderTimerPoint = SIMD3<Float>()
+
     // 별 모델 + 타이머
     private(set) var numberOfObjects: Int = 9
-    private var lastStarEntityTransform = Transform() //ShoulderTimer의 위치를 잡기 위한 변수
-    private var shoulderTimerPoint = SIMD3<Float>()
-    var timerController: AnimationPlaybackController?
-    var shoulderTimerEntity = Entity()
     private(set) var expectedNextNumber = 0
+    private(set) var timerController: AnimationPlaybackController?
+    
+
     
     deinit {
         dump("\(self) deinited")

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -156,9 +156,6 @@ final class ShoulderStretchingViewModel {
         let rightShoulderPosition = simd_float3(rightHandTranslation.x, rightHandTranslation.y, 0.0)
         let leftShoulderPosition = simd_float3(-rightShoulderPosition.x, rightHandTranslation.y, 0.0)
         
-        // 손이 원점 기준으로 오른쪽에 있는지 왼쪽에 있는지에 따라 isRightSide를 결정
-//        let isRightSide = handTranslation.x > 0
-        
         if !isRightDone {
             let rightPoints = generateUniformEllipseArcPoints(
                 centerPosition: rightShoulderPosition,
@@ -254,8 +251,19 @@ final class ShoulderStretchingViewModel {
                 
                 contentEntity.addChild(shoulderTimerEntity)
                 modelEntities.append(shoulderTimerEntity)
-//                playAnimation(animationEntity: shoulderTimerEntity)
             }
+        }
+    }
+    
+    func setEntryRocket() async {
+        if let rootEntity = try? await Entity(named: "Shoulder/RocketScene.usda", in: realityKitContentBundle) {
+            entryRocketEntity = rootEntity
+            entryRocketEntity.name = "EntryRocket"
+            entryRocketEntity.position = .init(x: 0, y: 1, z: -1)
+            entryRocketEntity.transform.scale = .init(x: 0.1, y: 0.1, z: 0.1)
+            entryRocketEntity.transform.rotation = .init(angle: .pi/2, axis: .init(x: 0, y: 1, z: 0))
+            entryRocketTransForm = entryRocketEntity.transform
+            contentEntity.addChild(entryRocketEntity)
         }
     }
 }

--- a/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/1D572CEB-057A-41C3-B575-04C37501A3C0/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/1D572CEB-057A-41C3-B575-04C37501A3C0/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,4 @@
 {
-  "materialPreviewEnvironmentType" : 2,
-  "materialPreviewObjectType" : 0
+  "materialPreviewObjectType" : 0,
+  "materialPreviewEnvironmentType" : 2
 }

--- a/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/40999400-94CF-4EA8-9DAF-D6FEAE63B933/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/40999400-94CF-4EA8-9DAF-D6FEAE63B933/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,4 @@
 {
-  "materialPreviewEnvironmentType" : 2,
-  "materialPreviewObjectType" : 0
+  "materialPreviewObjectType" : 0,
+  "materialPreviewEnvironmentType" : 2
 }

--- a/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/ADCB3503-BD59-4B77-AEB0-CA9E6B440C86/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/ADCB3503-BD59-4B77-AEB0-CA9E6B440C86/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,4 @@
 {
-  "materialPreviewEnvironmentType" : 2,
-  "materialPreviewObjectType" : 0
+  "materialPreviewObjectType" : 0,
+  "materialPreviewEnvironmentType" : 2
 }

--- a/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/FD751839-A604-45E0-BCFA-C429AB88F34F/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
+++ b/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/PluginData/FD751839-A604-45E0-BCFA-C429AB88F34F/ShaderGraphEditorPluginID/ShaderGraphEditorPluginID
@@ -1,4 +1,4 @@
 {
-  "materialPreviewEnvironmentType" : 2,
-  "materialPreviewObjectType" : 0
+  "materialPreviewObjectType" : 0,
+  "materialPreviewEnvironmentType" : 2
 }

--- a/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/WorkspaceData/SceneMetadataList.json
+++ b/APPRO/Packages/RealityKitContent/Package.realitycomposerpro/WorkspaceData/SceneMetadataList.json
@@ -115,15 +115,6 @@
       [
         "ADCB3503-BD59-4B77-AEB0-CA9E6B440C86",
         "Root",
-        "Rocket"
-      ],
-      {
-        "isExpanded" : true,
-        "isLocked" : false
-      },
-      [
-        "ADCB3503-BD59-4B77-AEB0-CA9E6B440C86",
-        "Root",
         "shoulderrocketsmall",
         "Materials"
       ],

--- a/APPRO/Packages/RealityKitContent/Sources/RealityKitContent/RealityKitContent.rkassets/Shoulder/RocketScene.usda
+++ b/APPRO/Packages/RealityKitContent/Sources/RealityKitContent/RealityKitContent.rkassets/Shoulder/RocketScene.usda
@@ -10,7 +10,10 @@
 
 def Xform "Root"
 {
-    reorder nameChildren = ["Rocket", "Rocket"]
+    reorder nameChildren = ["Rocket", "RocketCollisionModel"]
+    float3 xformOp:scale = (8, 8, 8)
+    uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
     def "Rocket" (
         active = true
         customData = {
@@ -141,6 +144,55 @@ def Xform "Root"
                     }
                 }
             }
+        }
+    }
+
+    def Cube "RocketCollisionModel" (
+        active = true
+        prepend apiSchemas = ["MaterialBindingAPI"]
+    )
+    {
+        rel material:binding = </Root/RocketCollisionModel/DefaultMaterial>
+        double size = 0.2
+        float3 xformOp:scale = (1, 0.9, 1.8)
+        float3 xformOp:translate = (-0.05, 0, 0.03)
+        uniform token[] xformOpOrder = ["xformOp:translate", "xformOp:orient", "xformOp:scale"]
+
+        def Material "DefaultMaterial"
+        {
+            token outputs:surface.connect = </Root/RocketCollisionModel/DefaultMaterial/DefaultSurfaceShader.outputs:surface>
+
+            def Shader "DefaultSurfaceShader"
+            {
+                uniform token info:id = "UsdPreviewSurface"
+                color3f inputs:diffuseColor = (1, 1, 1)
+                float inputs:roughness = 0.75
+                token outputs:surface
+            }
+        }
+
+        def RealityKitComponent "Collider"
+        {
+            uint group = 1
+            uniform token info:id = "RealityKit.Collider"
+            uint mask = 4294967295
+            token type = "Default"
+
+            def RealityKitStruct "Shape"
+            {
+                float3 extent = (0.2, 0.2, 0.2)
+                token shapeType = "Box"
+
+                def RealityKitStruct "pose"
+                {
+                }
+            }
+        }
+
+        def RealityKitComponent "HierarchicalFade"
+        {
+            uniform token info:id = "RealityKit.HierarchicalFade"
+            float opacity = 0
         }
     }
 }


### PR DESCRIPTION
# 이슈
- close #30 

# 작업 사항
### RCP 수정
- RCP에서 Root 아래에 로켓 충돌감지를 위한 Cube ModelEntity를 투명하게 opacity 0으로 추가하고 충돌 컴포넌트 등록

### HandModelEntity 수정
- 뷰모델 내의 좌우 HandModelEntity를 각각 사용하던것을 하나의 모델엔터티로 통합했고, RCP에서 직접 충돌용 큐브를 생성했기 때문에 기존에 로켓 충돌용으로 썼던 MarkerModel을 삭제하고 주먹 인식을 위한 두 개 모델만 가지도록 수정

### 뷰모델 수정
- RCP에서 로드한 entryRocketEntity를 `복제`해 handRocketEntity로 만들어 사용 (RCP에서 로드 한번만하도록)
- 씬에서 로켓엔터티를 가져와서 애니메이션을 위한 entryRocketTransForm 지정 하고 entryRocketTransForm에서 rightHandTransform로의 애니메이션을 실행하는 메서드 정의
- 엔트리 로켓 애니메이션 실행시 to 파라미터인 rightHandTransform을 from 파라미터 transForm의 scale을 동일하게 설정
(rightHandTransform의 scale이 기본값으로 세팅되어 있어 entryRocketTransForm의 스케일과 맞지 않는 문제 있었음)

### 뷰 수정
- 씬에서 로켓과 같은 크기로 투명하게 생성한 큐브 모델 엔터티를 entryRocketModel에서 찾아서 구독
- 엔트리 로켓을 손에서 쓸때 처럼 기존에 별 모델을 포물선을 그릴때마다 RCP에서 불러왔던것을 이를 뷰의 task클로저에서 뷰모델의 starModelEntity에 먼저 로드시키고 포물선을 그릴때는 불러온 모델을 복제해서 사용하는 방식으로 리팩토링

# 고민 or 참고 사항 (선택)

- 기존에 코드로 충돌체를 가진 MarkerModel을 생성하고 그 자식으로 로켓을 넣어서 MarkerModel을 구독하게 했었는데 이게 문제가 투명 메테리얼로 적용을 하더라도 그 잔상이 로켓위에 여전히 보이는 문제가 있었고, MarkerModel의 opacity를 주면 그 자식인 로켓 모델에도 opacity가 적용되어서 opacity를 못 쓴다는 문제가 있었는데 
 지난번 PR에서 구독 관련해서 @MartyTheGout가 좋은 피드백을 주셔서  MarkerModel을 없애고 RCP에서 아예 로켓과 비슷한 크기로 충돌체를 만든 투명한 큐브를 로켓과 같은 계층으로 만들어서 구독시 그 큐브를 구독하게 하였습니다. 
 
### 엔터티는 충돌 이벤트 구독이 안됨
-  이번에 뷰의 make클로저에서 await viewModel.setEntryRocket()를 실행하고 구독 메서드를 실행하게 해서 로켓을 RCP에서 로드하고 나서 구독을 할  수 있게 했는데 제가 착각했던게 .subscribe 메서드의 on 파라미터에 Entity를 넣을 수 있기에 RCP에서 가져온 rocket 씬 엔터티에 .generateCollisionShapes(recursive: true) 로하고 그 엔터티를 구독하면 엔터티 내에 있는 충돌체를 가지고 있는 모델에 충돌을 감지 할 수 있다고 생각했는데, 애초에 Entity를 구독하면 실제 충돌이 구독한 Entity의 자식에게 발생한다 하더라고 그 충돌을 감지를 못한다는 것이였습니다. 
- 결국 충돌 이벤트 구독은 충돌체를 가질 수 있는 ModelEntity만 가능한것 같습니다. 그래서 아예 로켓 씬에서 충돌용 큐브를 로켓크기로 만들어서 그 큐브를 구독하게 했습니다. (로켓이 하나의 Model이였으면 그 모델을 구독 할 수 있었으나 로켓이 여러개의 모델로 이루어져있어서 큐브로 사용)

- 추가적으로 이번에 로켓이랑 별 모델 둘다 RCP에서 반복적으로 모델을 불러오는 대신에 처음에 한번 불러오고 entity.clone(recursive: true) 가져온 엔터티를 복제해서 사용하도록 했습니다. 수치적으로 증명하는 방법은 모르겠지만 RCP에서 매번 불러오는 것보다 복제해서 쓰는게 나을 것 같습니다.

위 참고사항 이나 이번 PR 관련 피드백 부탁드립니다!

# 스크린샷 (선택)
<img width="716" alt="Screenshot 2024-11-03 at 12 29 11 AM" src="https://github.com/user-attachments/assets/42af1de1-830e-41fc-96a2-525e2cd3bdc1">

주먹 쥐면 로켓이 손쪽으로 옴

https://github.com/user-attachments/assets/0a19074f-39ee-40f9-82dc-276908bc7d81

