### PR TITLE
Feat:손목 튜토리얼 추가 + Tutorial Manager의 추가적으로 필요한 기능들

### DIFF
--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -75,13 +75,15 @@ struct APPROApp: App {
     private func tutorialImmersiveView(part: StretchingPart) -> some View {
         switch part {
         case .eyes:
-            EyeTutorialImmersiveView()
+            // TODO: 눈 튜토리얼 몰입 뷰 추가
+            EmptyView()
         case .shoulder:
             // TODO: 어깨 튜토리얼 몰입 뷰 추가
             EmptyView()
         case .wrist:
             // TODO: 손목 튜토리얼 몰입 뷰 추가
-            EmptyView()
+            HandRollingTutorialView()
+                .environment(appState)
         }
     }
     

--- a/APPRO/APPRO/Views/StretchingProcess/StretchingAttachmentView.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/StretchingAttachmentView.swift
@@ -47,12 +47,6 @@ struct StretchingAttachmentView: View {
                     }
                 }
             }
-            
-            Button {
-                UserDefaults.standard.setValue(false, forKey: "\(stretchingPart)TutorialSkipped")
-            } label: {
-                Text("Reset the Tutorial's User Default Value")
-            }
         }
         .frame(width: 550)
         .padding(24)

--- a/APPRO/APPRO/Views/StretchingProcess/StretchingAttachmentView.swift
+++ b/APPRO/APPRO/Views/StretchingProcess/StretchingAttachmentView.swift
@@ -47,6 +47,12 @@ struct StretchingAttachmentView: View {
                     }
                 }
             }
+            
+            Button {
+                UserDefaults.standard.setValue(false, forKey: "\(stretchingPart)TutorialSkipped")
+            } label: {
+                Text("Reset the Tutorial's User Default Value")
+            }
         }
         .frame(width: 550)
         .padding(24)

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
@@ -8,11 +8,9 @@
 import SwiftUI
 import RealityKit
 import RealityKitContent
-import ARKit
 
 struct HandRollingStretchingView: View {
     @State var viewModel = HandRollingStretchingViewModel()
-    @Environment(AppState.self) private var appState
     
     var body: some View {
         RealityView { content, attachments in
@@ -117,32 +115,15 @@ struct HandRollingStretchingView: View {
             }
         }
         .onChange(of: viewModel.rightHitCount, initial: false ) { oldNumber, newNumber in
-            if oldNumber > newNumber {
+            if oldNumber < newNumber {
                 dump(viewModel.doneCount)
                 viewModel.doneCount += 1
             }
         }
         .onChange(of: viewModel.leftHitCount, initial: false ) { oldNumber, newNumber in
-            if oldNumber > newNumber {
+            if oldNumber < newNumber {
                 dump(viewModel.doneCount)
                 viewModel.doneCount += 1
-            }
-        }
-        .onChange(of: viewModel.score, initial: false ) { _, changedScore  in
-            appState.doneCount = changedScore
-        }
-        .onChange(of: viewModel.rightGuideSphere.scale.x, initial: false ) { oldScale, newScale in
-            if newScale > oldScale {
-                Task {
-                    try? await viewModel.playSpatialAudio(viewModel.rightGuideRing, audioInfo: .handGuideSphereAppear)
-                }
-            }
-        }
-        .onChange(of: viewModel.leftGuideSphere.scale.x, initial: false ) { oldScale, newScale in
-            if newScale > oldScale {
-                Task {
-                    try? await viewModel.playSpatialAudio(viewModel.leftGuideRing, audioInfo: .handGuideSphereAppear)
-                }
             }
         }
         .onChange(of: viewModel.isStartingObjectVisible, initial: false) {_, newValue in

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+CollisionHandling.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+CollisionHandling.swift
@@ -99,7 +99,9 @@ extension HandRollingStretchingViewModel {
             try? await playSpatialAudio(targetEntity, audioInfo: AudioFindHelper.handTargetHitWrong(chirality: targetChiralityValue))
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4 ) {
-                self.getWrongTargetColorChange(target as! ModelEntity, chirality: targetChiralityValue, intChangeTo: 0)
+                if let modelEntity = target as? ModelEntity {
+                    self.getWrongTargetColorChange(modelEntity, chirality: targetChiralityValue, intChangeTo: 0)
+                }
             }
         }
     }

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel.swift
@@ -26,7 +26,6 @@ final class HandRollingStretchingViewModel: StretchingCounter {
     var isLeftHandInFist = false
     
     let stretchingAttachmentViewID  = "StretchingAttachmentView"
-    let threshold: Float = 0.1
     
     let frameInterval = 1
     var frameIndex = 0
@@ -36,17 +35,11 @@ final class HandRollingStretchingViewModel: StretchingCounter {
     var maxCount = StretchingPart.wrist.maxCount
     
     //RealityViewContent
-    var orb = ModelEntity()
-    
-    var indexJointEntity = ModelEntity()
-    
     var leftEntities: [Entity] = []
     var rightEntities: [Entity] = []
     
     var leftTargetEntities : [Entity] = []
     var rightTargetEntities : [Entity] = []
-    
-    var showGuideRing: Bool = false
     
     var rightGuideRing = Entity()
     var rightGuideSphere = ModelEntity()
@@ -237,4 +230,3 @@ final class HandRollingStretchingViewModel: StretchingCounter {
         content.add(stretchingAttachmentView)
     }
 }
-

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
@@ -1,0 +1,133 @@
+//
+//  HandRollingTutorialView.swift
+//  APPRO
+//
+//  Created by marty.academy on 11/7/24.
+//
+
+import SwiftUI
+import RealityKit
+import RealityKitContent
+
+struct HandRollingTutorialView : View {
+    
+    @State var viewModel = HandRollingTutorialViewModel()
+    @State var tutorialManager = TutorialManager(stretching: .wrist)
+    
+    var body : some View {
+        RealityView { content, attachments in
+            if viewModel.isStartingObjectVisible {
+                await viewModel.generateStartingObject(content)
+            }
+            
+            await viewModel.makeFirstEntitySetting(content)
+            viewModel.bringCollisionHandler(content)
+            viewModel.addAttachmentView(content, attachments)
+        } update : { content, attachments in
+            viewModel.addEntity(content)
+            
+            if viewModel.isRightHandInFist {
+                viewModel.updateGuideComponentsTransform(content, chirality: .right)
+            }
+            
+            viewModel.addAttachmentView(content, attachments)
+            
+        } attachments: {
+            Attachment(id: viewModel.tutorialAttachmentViewID) {
+                TutorialAttachmentView(tutorialManager: tutorialManager)
+            }
+        }
+        .task {
+            await viewModel.start()
+        }
+        .task {
+            await viewModel.publishHandTrackingUpdates()
+        }
+        .task {
+            await viewModel.monitorSessionEvents()
+        }
+        .onChange(of: viewModel.isRightHandInFist, initial: false) { _, isHandFistShape in
+            if !viewModel.isFistMakingTutorialDone {
+                getNextTutorialStep(0)
+                viewModel.isFistMakingTutorialDone = true
+            }
+            
+            if isHandFistShape {
+                if viewModel.isStartingObjectVisible { viewModel.isStartingObjectVisible = false}
+                
+                viewModel.rightEntities.append(viewModel.rightGuideRing)
+                if tutorialManager.currentStepIndex > 1 {
+                    viewModel.rightEntities.append(viewModel.rightGuideSphere)
+                }
+                
+                Task {
+                    try? await viewModel.playSpatialAudio(viewModel.rightGuideRing, audioInfo: AudioFindHelper.handGuideRingAppear)
+                }
+            } else {
+                viewModel.rightGuideRing.removeFromParent()
+                viewModel.rightGuideSphere.removeFromParent()
+                viewModel.rightEntities.removeAll()
+            }
+        }
+        .onChange(of: viewModel.isStartingObjectVisible, initial: false) {_, newValue in
+            if !newValue {
+                viewModel.getRidOfStartingObject()
+            }
+        }
+        .onChange(of: tutorialManager.currentStepIndex, initial: false ) { _, currentStepIndex in
+            getNextTutorialStep(1)
+            getNextTutorialStep(2)
+            getNextTutorialStep(5)
+        }
+        .onChange(of: viewModel.rightLaunchState, initial: false) { _, currentLaunchState in
+            if currentLaunchState {
+                Task {
+                    viewModel.rightRotationForLaunchNumber = viewModel.rightRotationCount
+                    try? await viewModel.rightEntities.append(viewModel.generateLaunchObj(chirality: .right))
+                }
+                
+                DispatchQueue.main.async {
+                    viewModel.rightLaunchState = false
+                    viewModel.rightRotationCount = 0
+                    getNextTutorialStep(4)
+                }
+            }
+        }
+        .onChange(of: viewModel.rightRotationCount, initial: false) { _, newValue in
+            let colorValueChangedTo = min (newValue * 2, 6)
+            viewModel.getDifferentRingColor(viewModel.rightGuideRing, intChangeTo: Int32(colorValueChangedTo))
+            
+            Task {
+                await viewModel.playRotationChangeRingSound(newValue)
+            }
+            
+            getNextTutorialStep(3)
+        }
+        .onChange(of: viewModel.rightHitCount, initial: false ) { oldNumber, newNumber in
+            if oldNumber < newNumber {
+                viewModel.doneCount += 1
+            }
+        }
+        .onChange(of: viewModel.rightTargetEntity, initial: false ) {_, newOne in
+            // 0...5 : step 의 인덱스들 -> 이 이중에서 과녁이 없어진다면, 4, 5 단계 빼고는 유저가 튜토리얼 하는 과정에서 과녁을 없앤다면 새롭게 나와야한다. 
+            if newOne.name != "GreenTarget_right" && tutorialManager.currentStepIndex >= 2 && tutorialManager.currentStepIndex < 4 {
+                Task {
+                    await viewModel.rightTargetEntity = viewModel.bringTargetEntity(chirality: .right)
+                }
+            }
+        }
+    }
+    
+    private func getNextTutorialStep(_ currentStepIndex: Int) {
+        if tutorialManager.currentStepIndex == currentStepIndex {
+            if currentStepIndex == 2 {
+                viewModel.showTarget = true
+            }
+            tutorialManager.completeCurrentStep()
+        }
+    }
+}
+
+#Preview {
+    HandRollingTutorialView()
+}

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+CollisionHandling.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+CollisionHandling.swift
@@ -1,8 +1,8 @@
 //
-//  HandRollingStretchingViewModel+CollisionHandling.swift
+//  HandRollingTutorialViewModel.swift
 //  APPRO
 //
-//  Created by marty.academy on 10/31/24.
+//  Created by marty.academy on 11/7/24.
 //
 
 import SwiftUI
@@ -10,7 +10,7 @@ import ARKit
 import RealityKit
 import RealityKitContent
 
-extension HandRollingStretchingViewModel {
+extension HandRollingTutorialViewModel {
     
     func bringCollisionHandler(_ content: RealityViewContent) {
         _ = content.subscribe(to: CollisionEvents.Began.self, on: nil) { collisionEvent in
@@ -34,23 +34,6 @@ extension HandRollingStretchingViewModel {
                 for index in 0..<self.rightRotationCollisionArray.count {
                     self.rightRotationCollisionArray[index] = false
                 }
-                
-            }
-            
-            // rotation recognition handling : left
-            if entityA.name == "GuideSphere_Left" && entityB.name.contains(regex)  {
-                let index: Int = Int(String(entityB.name.last!)) ?? 0
-                self.leftRotationCollisionArray[index] = true
-            } else if entityB.name == "GuideSphere_Left" && entityA.name.contains(regex) {
-                let index: Int = Int(String(entityA.name.last!)) ?? 0
-                self.leftRotationCollisionArray[index] = true
-            }
-            
-            if self.leftRotationCollisionArray.filter({ $0 == false }).isEmpty {
-                self.leftRotationCount += 1
-                for index in 0..<self.leftRotationCollisionArray.count {
-                    self.leftRotationCollisionArray[index] = false
-                }
             }
             
             Task {
@@ -68,7 +51,6 @@ extension HandRollingStretchingViewModel {
                     }
                 }
             }
-            
         }
     }
     
@@ -106,25 +88,15 @@ extension HandRollingStretchingViewModel {
     
     private func removeTargetFromArrayAndContext (targetEntity: Entity, chirality: Chirality, canBeCountedAsScore: Bool) {
         targetEntity.removeFromParent()
-        
-        if chirality == .left  {
-            guard let index = leftTargetEntities.firstIndex(where: {$0.name == targetEntity.name} ) else { return }
-            leftTargetEntities.remove(at: index)
-            if canBeCountedAsScore {
-                leftHitCount += 1
-            }
-            
-        } else {
-            guard let index = rightTargetEntities.firstIndex(where: {$0.name == targetEntity.name} ) else { return }
-            rightTargetEntities.remove(at: index)
-            if canBeCountedAsScore {
-                rightHitCount += 1
-            }
+
+        rightTargetEntity = Entity()
+        if canBeCountedAsScore {
+            rightHitCount += 1
         }
     }
     
     private func getChiralityValue (_ string: String) -> String {
-        let regex = try! NSRegularExpression(pattern: "(?<=_)(right|left)(?=_)", options: [])
+        let regex = try! NSRegularExpression(pattern: "(?<=_)(right|left)", options: [])
         if let match = regex.firstMatch(in: string, options: [], range: NSRange(location: 0, length: string.utf16.count)) {
             if let range = Range(match.range(at: 1), in: string) {
                 let result = String(string[range])

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+CollisionHandling.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+CollisionHandling.swift
@@ -81,7 +81,9 @@ extension HandRollingTutorialViewModel {
             try? await playSpatialAudio(targetEntity, audioInfo: AudioFindHelper.handTargetHitWrong(chirality: targetChiralityValue))
             
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.4 ) {
-                self.getWrongTargetColorChange(target as! ModelEntity, chirality: targetChiralityValue, intChangeTo: 0)
+                if let modelEntity = target as? ModelEntity {
+                    self.getWrongTargetColorChange(modelEntity, chirality: targetChiralityValue, intChangeTo: 0)
+                }
             }
         }
     }

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+HandTracking.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+HandTracking.swift
@@ -1,0 +1,97 @@
+//
+//  HandRollingTutorialViewModel.swift
+//  APPRO
+//
+//  Created by marty.academy on 11/7/24.
+//
+
+import SwiftUI
+import RealityKit
+import RealityKitContent
+import ARKit
+
+
+extension HandRollingTutorialViewModel {
+    func start() async {
+        do {
+            if HandTrackingProvider.isSupported {
+                try await session.run([handTracking])
+            } else {
+                print("hand tracking: \(HandTrackingProvider.isSupported)")
+            }
+            
+        } catch {
+            print("ARKitSession error:", error)
+        }
+    }
+    
+    func publishHandTrackingUpdates() async {
+        
+        for await update in handTracking.anchorUpdates {
+            switch update.event {
+            case .updated:
+                let anchor = update.anchor
+                
+                guard anchor.isTracked else { continue }
+                
+                if anchor.chirality == .left {
+                    latestHandTracking.left = anchor
+                    isHandinFistShape(chirality: .left)
+                } else if anchor.chirality == .right {
+                    latestHandTracking.right = anchor
+                    isHandinFistShape(chirality: .right)
+                }
+                
+            default:
+                break
+            }
+        }
+    }
+    
+    func isHandinFistShape(chirality: Chirality) {
+        guard let handAnchor = chirality == .right ? latestHandTracking.right : latestHandTracking.left else { return  }
+        
+        guard
+            let thumbJoint = handAnchor.handSkeleton?.joint(.thumbIntermediateBase),
+            let indexJoint = handAnchor.handSkeleton?.joint(.indexFingerIntermediateTip),
+            thumbJoint.isTracked && indexJoint.isTracked else { return }
+        
+        let thumbJointOriginalTransform = matrix_multiply(handAnchor.originFromAnchorTransform, thumbJoint.anchorFromJointTransform).columns.3
+        let indexJointOriginalTransfrom = matrix_multiply(handAnchor.originFromAnchorTransform, indexJoint.anchorFromJointTransform).columns.3
+        
+        let distance = distance(thumbJointOriginalTransform, indexJointOriginalTransfrom)
+        
+        let isFistShape = distance <= 0.04
+        let isPalmOpened = distance >= 0.09
+        
+        if chirality == .right {
+            if isRightHandInFist {
+                isRightHandInFist = !isPalmOpened
+            } else {
+                isRightHandInFist = isFistShape
+            }
+        }
+    }
+    
+    func getJointPosition(_ jointName: HandSkeleton.JointName, chirality : Chirality) -> simd_float3 {
+        guard let handAnchor = chirality == .right ? latestHandTracking.right : latestHandTracking.left else { return .init() }
+        guard let joint = handAnchor.handSkeleton?.joint(jointName) else { return .init() }
+        
+        let selectedJointOriginalTransfrom = matrix_multiply(handAnchor.originFromAnchorTransform, joint.anchorFromJointTransform).columns.3
+        
+        return simd_float3(selectedJointOriginalTransfrom.x, selectedJointOriginalTransfrom.y, selectedJointOriginalTransfrom.z)
+    }
+    
+    func monitorSessionEvents() async {
+        for await event in session.events {
+            switch event {
+            case .authorizationChanged(let type, let status):
+                if type == .handTracking && status != .allowed {
+                }
+                
+            default:
+                print("Session event \(event)")
+            }
+        }
+    }
+}

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+SprialLaunching.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+SprialLaunching.swift
@@ -1,0 +1,110 @@
+//
+//  HandRollingStretchingViewModel+SprialLaunching.swift
+//  APPRO
+//
+//  Created by marty.academy on 10/31/24.
+//
+
+import SwiftUI
+import ARKit
+import RealityKit
+import RealityKitContent
+
+extension HandRollingTutorialViewModel {
+    
+    func generateLaunchObj(chirality: Chirality) async throws -> Entity {
+        if let custom3DObject = try? await Entity(named: "Hand/spiral_new", in: realityKitContentBundle) {
+            let rotationNumber = rightRotationForLaunchNumber
+            custom3DObject.name = "Spiral_\(chirality)_\(rotationNumber)"
+            
+            custom3DObject.components.set(GroundingShadowComponent(castsShadow: true))
+            custom3DObject.components.set(InputTargetComponent())
+            custom3DObject.generateCollisionShapes(recursive: true)
+            
+            custom3DObject.scale = .init(repeating: 0.01)
+            
+            let physicsMaterial = PhysicsMaterialResource.generate(
+                staticFriction: 0.01,
+                dynamicFriction: 0.01,
+                restitution: 1.5
+            )
+            
+            var physicsBody = PhysicsBodyComponent(massProperties: .default, material: physicsMaterial, mode: .dynamic)
+            physicsBody.isAffectedByGravity = false
+            physicsBody.massProperties.mass = 0.01
+            
+            let startingCriteria = rightGuideRing
+            custom3DObject.transform = startingCriteria.transform
+            
+            let forwardDirection = startingCriteria.transform.matrix.columns.0 // x axis
+            let direction = simd_float3(forwardDirection.x, forwardDirection.y, forwardDirection.z)
+            let adjustedTranslation = startingCriteria.position - direction * 0.25
+            
+            custom3DObject.transform.translation = adjustedTranslation
+            
+            if let modelEntity = custom3DObject.findEntity(named: "Spiral") as? ModelEntity {
+                modelEntity.components[PhysicsBodyComponent.self] = physicsBody
+            }
+            
+            try await animating(entity: custom3DObject, chirality: chirality)
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                if chirality == .right {
+                    guard let indexOfEntity = self.rightEntities.firstIndex(where: { $0.name == custom3DObject.name}) else { return }
+                    self.rightEntities.remove(at: indexOfEntity)
+                }
+                custom3DObject.removeFromParent()
+            }
+            
+            return custom3DObject
+        }
+        
+        return Entity()
+    }
+    
+    func findResourceAndPlay(_ entity: Entity, spatialAudioName: String, resourceLocation: String, resourceFrom: String) async throws {
+        guard let audioEntity = entity.findEntity(named: spatialAudioName),
+              let resource = try? await AudioFileResource(named: resourceLocation,
+                                                          from: resourceFrom,
+                                                          in: realityKitContentBundle) else {
+            print("No Audio Resource Found:  \(resourceLocation) / \(resourceFrom) \(spatialAudioName)")
+            return }
+        
+        let audioPlayer = audioEntity.prepareAudio(resource)
+        audioPlayer.play()
+    }
+    
+    func playSpatialAudio(_ entity: Entity, audioInfo: AudioFindHelper) async throws {
+        let audioInfoDetail = audioInfo.detail
+        try await findResourceAndPlay(entity, spatialAudioName: audioInfoDetail.spatialAudioName, resourceLocation: audioInfoDetail.resourceLocation, resourceFrom: audioInfoDetail.resourceFrom)
+    }
+    
+    func animating(entity : Entity, chirality : Chirality) async throws {
+        let multiplication = entity.transform.matrix
+        let forwardDirection = multiplication.columns.0 // x axis
+        let direction = simd_float3(forwardDirection.x, forwardDirection.y, forwardDirection.z)
+        
+        let moveTargetPosition = chirality == .left ? entity.position - direction * 1.5 : entity.position + direction * 1.5
+        
+        var shortTransform = entity.transform
+        shortTransform.scale = .init(repeating: 0.1)
+        
+        var newTransform = entity.transform
+        newTransform.translation = moveTargetPosition
+        newTransform.scale = .init(repeating: 1)
+        
+        let goInDirection = FromToByAnimation<Transform> (
+            name: "launchFromWrist",
+            from: shortTransform,
+            to: newTransform,
+            duration: 0.5,
+            bindTarget: .transform
+        )
+        
+        let animation = try AnimationResource.generate(with: goInDirection)
+        
+        entity.playAnimation(animation, transitionDuration: 0.5)
+        
+        try await playSpatialAudio(entity, audioInfo: AudioFindHelper.handSprialAppear)
+    }
+}

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+UpdateTransform.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+UpdateTransform.swift
@@ -1,0 +1,122 @@
+//
+//  HandRollingTutorialViewModel.swift
+//  APPRO
+//
+//  Created by marty.academy on 11/7/24.
+//
+
+import SwiftUI
+import ARKit
+import RealityKit
+import RealityKitContent
+
+extension HandRollingTutorialViewModel {
+    
+    func updateGuideComponentsTransform(_ content: RealityViewContent, chirality:  Chirality) {
+        
+        let chiralityString = chirality == .right ? "Right" : "Left"
+        
+        guard let rightGuideRing = content.entities.first(where: {$0.name == "Ring_\(chiralityString)"}) else { return }
+        rightGuideRing.transform = calArmTransform(rightGuideRing.transform, chirality: chirality)
+        
+        guard let rightGuideSphere = content.entities.first(where: {$0.name == "GuideSphere_\(chiralityString)"}) else { return }
+        rightGuideSphere.position = calculateIntersectionWithWristRingPlane(chirality: chirality) ?? rightGuideSphere.position
+    }
+    
+    func calArmTransform(_ beforeTransform: Transform, chirality : Chirality) -> Transform {
+        guard let anchor = chirality == .right ? latestHandTracking.right : latestHandTracking.left else { return beforeTransform }
+        let joint = anchor.handSkeleton?.joint(.forearmArm)
+        
+        let smoothingFactor: Float = 0.05
+        
+        if ((joint?.isTracked) != nil) {
+            var t = matrix_multiply(anchor.originFromAnchorTransform, (joint?.anchorFromJointTransform)!)
+            
+            let directionColumns = t.columns.0
+            let directionVector = simd_float3(x: directionColumns.x, y: directionColumns.y, z: directionColumns.z)
+            
+            let ringLocation = chirality == .right ? simd_float3(x: t.columns.3.x, y: t.columns.3.y , z: t.columns.3.z ) + ( directionVector * 0.4 ) : simd_float3(x: t.columns.3.x, y: t.columns.3.y , z: t.columns.3.z ) - ( directionVector * 0.4 )
+            
+            
+            t.columns.3.x = applyLinearInterpolation(current: ringLocation.x, previous: beforeTransform.translation.x, factor: smoothingFactor)
+            t.columns.3.y = applyLinearInterpolation(current: ringLocation.y, previous: beforeTransform.translation.y, factor: smoothingFactor)
+            t.columns.3.z = applyLinearInterpolation(current: ringLocation.z, previous: beforeTransform.translation.z, factor: smoothingFactor)
+            
+            var newTransform = Transform(matrix: t)
+            
+            let currentRotation = newTransform.rotation
+            let smoothedRotation = simd_normalize(simd_slerp(beforeTransform.rotation, currentRotation, smoothingFactor))
+            
+            newTransform.rotation = smoothedRotation
+            
+            return newTransform
+        }
+        return beforeTransform
+    }
+    
+    func calculateIntersectionWithWristRingPlane(chirality : Chirality) -> simd_float3? {
+        let wristRingTransform = rightGuideRing.transform
+        
+        let middleKnucklePosition = getJointPosition(.middleFingerKnuckle, chirality: chirality)
+        let vector = middleKnucklePosition - getJointPosition(.wrist, chirality: chirality)
+        let normalizedVector = normalize(vector)
+        
+        let wristRingY = simd_float3(wristRingTransform.matrix.columns.1.x,
+                                     wristRingTransform.matrix.columns.1.y,
+                                     wristRingTransform.matrix.columns.1.z)
+        let wristRingZ = simd_float3(wristRingTransform.matrix.columns.2.x,
+                                     wristRingTransform.matrix.columns.2.y,
+                                     wristRingTransform.matrix.columns.2.z)
+        
+        let planeNormal = cross(wristRingY, wristRingZ)
+        let wristRingPosition = simd_float3(wristRingTransform.matrix.columns.3.x,
+                                            wristRingTransform.matrix.columns.3.y,
+                                            wristRingTransform.matrix.columns.3.z)
+        
+        let denominator = dot(planeNormal, normalizedVector)
+        if abs(denominator) < 1e-6 {
+            return nil // 벡터가 평면과 평행한 경우 교차점이 없음
+        }
+        
+        let t = dot(planeNormal, wristRingPosition - middleKnucklePosition) / denominator
+        
+        let intersection3D = middleKnucklePosition + normalizedVector * t
+        
+        let distanceToCenter = length(intersection3D - wristRingPosition)
+        if distanceToCenter <= ( radius / 4 )  {
+            if chirality == .right {
+                rightGuideSphere.scale = .init(repeating: 0.01)
+                if rightRotationCount > 0 && !rightLaunchState {
+                    DispatchQueue.main.async {
+                        self.rightLaunchState = true //TODO: 회전폭 반경은 더욱 좁게 설정되어야할 수도 있음.
+                    }
+                }
+            }
+            return intersection3D
+        }
+        
+        if rightGuideSphere.scale.x < 1  {
+            rightGuideSphere.scale = .init(repeating: 1)
+        }
+            
+        
+        let directionVector = normalize(intersection3D - wristRingPosition)
+        // 원 경계에 해당하는 지점 계산
+        let pointOnBoundary = wristRingPosition + directionVector * radius
+        return pointOnBoundary
+    }
+    
+    private func applyLinearInterpolation (current : Float, previous : Float, factor:Float) -> Float {
+        return previous + (current - previous) * factor
+    }
+    
+    func playRotationChangeRingSound(_ newValue: Int) async {
+        if newValue >= 3 {
+            try? await playSpatialAudio(rightGuideRing, audioInfo: AudioFindHelper.handRotationThreeTimes)
+        } else if newValue == 2 {
+            try? await playSpatialAudio(rightGuideRing, audioInfo: AudioFindHelper.handRotationTwice)
+        } else if newValue == 1 {
+            try? await playSpatialAudio(rightGuideRing, audioInfo: AudioFindHelper.handRotationOnce)
+        }
+    }
+}

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
@@ -1,0 +1,158 @@
+//
+//  HandRollingTutorialViewModel.swift
+//  APPRO
+//
+//  Created by marty.academy on 11/7/24.
+//
+
+import SwiftUI
+import RealityKit
+import RealityKitContent
+import ARKit
+
+@Observable
+@MainActor
+final class HandRollingTutorialViewModel {
+    
+    let session = ARKitSession()
+    var handTracking = HandTrackingProvider()
+    
+    var latestHandTracking: HandsUpdates = .init(left: nil, right: nil)
+    
+    var isStartingObjectVisible = true
+    var startObject = Entity()
+    
+    var isRightHandInFist = false
+    
+    let tutorialAttachmentViewID = "TutorialAttachmentView"
+    
+    //StretchingCounter
+    var doneCount = 0
+    
+    //RealityViewContent
+    var rightEntities: [Entity] = []
+    var rightTargetEntity : Entity = Entity()
+    
+    var rightGuideRing = Entity()
+    var rightGuideSphere = ModelEntity()
+    
+    let radius: Float = 0.1
+    
+    var rightRotationForLaunchNumber : Int = 0
+    var rightRotationCount: Int = 0
+    var rightRotationCollisionArray = [ false, false, false, false]
+    
+    var rightLaunchState = false
+    var leftLaunchState = false
+    
+    var rightHitCount = 0
+    
+    
+    // Tutorial Related
+    var isFistMakingTutorialDone = false
+    var showTarget = false
+    
+    func makeFirstEntitySetting (_ content: RealityViewContent) async {
+        rightGuideRing = await generateGuideRing(chirality: .right)
+        rightGuideSphere = generateGuideSphere(chirality: .right)
+        
+        rightTargetEntity = await bringTargetEntity( chirality: .right)
+    }
+    
+    func addEntity(_ content: RealityViewContent) {
+        for entity in rightEntities {
+            content.add(entity)
+        }
+        
+        if !isStartingObjectVisible {
+            content.add(rightTargetEntity)
+        }
+        
+        if showTarget {
+            content.add(rightTargetEntity)
+        }
+    }
+    
+    func generateStartingObject(_ content: RealityViewContent) async {
+        guard let entity = try? await Entity(named: "Hand/main_obj_applied", in: realityKitContentBundle) else { return }
+        entity.name = "StartingObject"
+        
+        startObject = entity
+        startObject.transform.translation = .init(x: 0, y: 1.4, z: -1.0)
+        
+        guard let animation = startObject.availableAnimations.first else {return}
+        startObject.playAnimation(animation.repeat(duration: .infinity), transitionDuration: 6.9, startsPaused: false)
+        
+        content.add(entity)
+    }
+    
+    func getRidOfStartingObject () {
+        startObject.removeFromParent()
+    }
+    
+    func generateGuideRing(chirality : Chirality) async  -> Entity  {
+        guard let guideRingEntity = try? await Entity(named: "Hand/wrist_ring", in: realityKitContentBundle) else { return Entity() }
+        guideRingEntity.name = chirality == .right ?  "Ring_Right" : "Ring_Left"
+        
+        return guideRingEntity
+    }
+    
+    func generateGuideSphere(chirality : Chirality)-> ModelEntity  {
+        let guideSphereEntity = ModelEntity(mesh: .generateSphere(radius: 0.015), materials: [SimpleMaterial(color: .red, roughness: 0.0, isMetallic: false)]) // var to let
+        guideSphereEntity.name = chirality == .right ? "GuideSphere_Right" : "GuideSphere_Left"
+        guideSphereEntity.generateCollisionShapes(recursive: false)
+        
+        return guideSphereEntity
+    }
+    
+    func bringTargetEntity (chirality: Chirality) async -> Entity {
+        guard let targetEntity = try? await Entity(named: "Hand/target_new_green", in: realityKitContentBundle) else { return Entity() }
+        
+        var transform = targetEntity.transform
+        transform.translation = .init(x: -0.6, y: 1.6, z: -1)
+        transform.rotation = getRotationCalculator(transform.rotation, rotationX: 1/7 * .pi, rotationY: -1/3 * .pi, rotationZ: 0)
+        transform.scale = transform.scale * 0.8
+        
+        let entityName = chirality == .left ? "BlueTarget_left" :"GreenTarget_right"
+        
+        targetEntity.name = entityName
+        targetEntity.transform = transform
+        
+        return targetEntity
+    }
+    
+    private func getRotationCalculator(_ currentRotation: simd_quatf, rotationX: Float, rotationY: Float, rotationZ: Float) -> simd_quatf {
+        let localXAxis = normalize(currentRotation.act(SIMD3<Float>(1, 0, 0)))
+        let localYAxis = normalize(currentRotation.act(SIMD3<Float>(0, 1, 0)))
+        let localZAxis = normalize(currentRotation.act(SIMD3<Float>(0, 0, 1)))
+        
+        let rotationXQuat = simd_quatf(angle: rotationX, axis: localXAxis)
+        let rotationYQuat = simd_quatf(angle: rotationY, axis: localYAxis)
+        let rotationZQuat = simd_quatf(angle: rotationZ, axis: localZAxis)
+        
+        return currentRotation * rotationXQuat * rotationYQuat * rotationZQuat
+    }
+    
+    func addAttachmentView(_ content: RealityViewContent, _ attachments: RealityViewAttachments) {
+        guard let tutorialAttachmentView = attachments.entity(for: tutorialAttachmentViewID) else {
+            dump("TutorialAttachmentView not found in attachments!")
+            return
+        }
+        tutorialAttachmentView.position = .init(x: 0, y: 2.0, z: -1.2) // TODO: 추후수정
+        content.add(tutorialAttachmentView)
+    }
+    
+    func getDifferentRingColor(_ ringEntity : Entity, intChangeTo: Int32) {
+        guard let modelEntity = ringEntity.findEntity(named: "Torus") else {return }
+
+        guard var modelComponent = modelEntity.components[ModelComponent.self],
+              var shaderGraphMaterial = modelComponent.materials.first as? ShaderGraphMaterial
+        else { return  }
+
+        do {
+            try shaderGraphMaterial.setParameter(name: "RingColor", value: .int(intChangeTo) )
+            modelComponent.materials = [shaderGraphMaterial]
+            modelEntity.components.set(modelComponent)
+        } catch {}
+    }
+}

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -11,6 +11,7 @@ struct TutorialAttachmentView: View {
     
     @State private var showSkipAlert = false
     @Bindable var tutorialManager: TutorialManager
+    @Environment(AppState.self) var appState: AppState
     
     var body: some View {
         if let currentStep = tutorialManager.currentStep {
@@ -35,7 +36,13 @@ struct TutorialAttachmentView: View {
                         .lineLimit(3)
                     Spacer()
                     Button(tutorialManager.isLastStep ? "Done" : "Next") {
-                        tutorialManager.advanceToNextStep()
+                        if tutorialManager.isLastStep {
+                            tutorialManager.skip()
+                            appState.appPhase = .stretching
+                        } else {
+                            tutorialManager.advanceToNextStep()
+                        }
+                        
                     }
                     .font(.title3)
                     .disabled(!currentStep.isCompleted)
@@ -81,7 +88,7 @@ struct TutorialAttachmentView: View {
             .frame(maxWidth: .infinity, maxHeight: 44)
             .buttonStyle(.borderless)
         }
-        .frame(width: 320, height: 240)
+        .frame(width: 320, height: tutorialManager.stretchingPart == .wrist ? 270 : 240)
         .padding(20)
         .glassBackgroundEffect()
     }

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -12,8 +12,8 @@ class TutorialManager {
     
     let stretchingPart: StretchingPart
     
-    private let steps: [TutorialStep]
-    private var currentStepIndex = 0
+    private var steps: [TutorialStep]
+    private(set) var currentStepIndex = 0
     
     init(stretching: StretchingPart) {
         self.stretchingPart = stretching
@@ -30,8 +30,7 @@ class TutorialManager {
     
     func completeCurrentStep() {
         guard var currentStep else { return }
-        
-        currentStep.isCompleted = true
+        steps[currentStepIndex].isCompleted = true
     }
     
     func advanceToNextStep() {


### PR DESCRIPTION
# 이슈
close #10 

# 작업 사항
- Tutorial View 구현: Hand Rolling
- Tutorial Attachment View : 빈과 이야기해본 결과 Done을 클릭시, 튜토리얼 스킵과도 같은 효과를 지니도록 하는 것이 의도된 행동으로, Done 클릭으로 *튜토리얼 스킵과 *appState.appPhase를 .tutorial -> .stretching으로 변경하는 것으로 ImmersiveView 의 전환을 할 수 있도록 설정. 
- TutorialManager: 
1) currentStepIndex 에 접근 가능하도록 변화
2) completeCurrentSteop을 호출 시에 Button의 Disalbed가 변화하지 않는 현상 제거 ( 밑의 고민 사항 참고) 
- TutorialAttachmentView : 
1) done 직전의 instruction 이 너무 길어서 짤리는 현상을 방지하고자 높이를 추가. 

기타: 
1) 빈 리뷰 참고하여, 오른쪽 왼쪽 혹은 충분한 회전회수가 아닌 경우에는 과녁을 사라지게 하지 않도록 처리. 
2) 사용하지 않는 저장값들 정리 

# 고민 or 참고 사항 (선택)
```swift

class TutorialManager {

  let stretchingPart: StretchingPart

  private var steps: [TutorialStep]
  private(set) var currentStepIndex = 0

  init(stretching: StretchingPart) {
      self.stretchingPart = stretching
  }

  func completeCurrentStep() {
      guard var currentStep else { return }
      steps[currentStepIndex].isCompleted = true
  }
```
completeCurrentStep 호출시, 예상되는 행동으로 진행되지 않는 것을 확인하였습니다. 
subscipt는 onlyget 이라는 메세지를 확인하였고, 위의 currentStep은 steps[index]의 복사된 값으로 추측됩니다. 따라서 변경시에도 steps의 false/true값에 영향이 가지 않아서 attachmentView에서도 버튼이 활성화되지 않았습니다. 

이에 currentStep 으로 outOfRange 에러를 회피하고, 직접 stes[currentIndex] = true 값으로 변경하는 식으로 로직을 변경하였습니다. 
짧은 식견으로, 보이는 문제만 해결한 꼴이 될 수도 있어서 조언을 받을 수 있을까하여 메세지 남깁니다. 

# 스크린샷 (선택)
