### PR TITLE
Fix: 손목돌리는 도중 손목이 풀리는 현상 개선

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+HandTracking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+HandTracking.swift
@@ -34,10 +34,10 @@ extension HandRollingStretchingViewModel {
                     
                     if anchor.chirality == .left {
                         latestHandTracking.left = anchor
-                        isHandinFistShape(chirality: .left)
+                        isHandInFistShape(chirality: .left)
                     } else if anchor.chirality == .right {
                         latestHandTracking.right = anchor
-                        isHandinFistShape(chirality: .right)
+                        isHandInFistShape(chirality: .right)
                     }
                     
                 default:
@@ -49,35 +49,55 @@ extension HandRollingStretchingViewModel {
         frameIndex += 1
     }
     
-    func isHandinFistShape(chirality: Chirality) {
-        guard let handAnchor = chirality == .right ? latestHandTracking.right : latestHandTracking.left else { return  }
+    func isHandInFistShape(chirality: Chirality) {
+        guard let handAnchor = (chirality == .right ? latestHandTracking.right : latestHandTracking.left),
+              let thumbJoint = handAnchor.handSkeleton?.joint(.thumbIntermediateBase),
+              let indexJoint = handAnchor.handSkeleton?.joint(.indexFingerIntermediateTip),
+              thumbJoint.isTracked, indexJoint.isTracked else { return }
         
-        guard
-            let thumbJoint = handAnchor.handSkeleton?.joint(.thumbIntermediateBase),
-            let indexJoint = handAnchor.handSkeleton?.joint(.indexFingerIntermediateTip),
-            thumbJoint.isTracked && indexJoint.isTracked else { return }
+        let thumbTransform = matrix_multiply(handAnchor.originFromAnchorTransform, thumbJoint.anchorFromJointTransform).columns.3
+        let indexTransform = matrix_multiply(handAnchor.originFromAnchorTransform, indexJoint.anchorFromJointTransform).columns.3
         
-        let thumbJointOriginalTransform = matrix_multiply(handAnchor.originFromAnchorTransform, thumbJoint.anchorFromJointTransform).columns.3
-        let indexJointOriginalTransfrom = matrix_multiply(handAnchor.originFromAnchorTransform, indexJoint.anchorFromJointTransform).columns.3
-        
-        let distance = distance(thumbJointOriginalTransform, indexJointOriginalTransfrom)
-        
+        let distance = distance(thumbTransform, indexTransform)
         let isFistShape = distance <= 0.04
         let isPalmOpened = distance >= 0.09
         
-        if chirality == .right {
-            if isRightHandInFist {
-                isRightHandInFist = !isPalmOpened
+        updateFistReader(for: chirality, isFistShape: isFistShape, isPalmOpened: isPalmOpened)
+    }
+    
+    private func updateFistReader(for chirality: Chirality, isFistShape: Bool, isPalmOpened: Bool) {
+        var fistReader = (chirality == .right ? fistReaderRight : fistReaderLeft)
+        let isHandInFist = (chirality == .right ? isRightHandInFist : isLeftHandInFist)
+        
+        // 주먹을 쥔 상태라면 손을 펴야지만 값을 인식, 그렇지 않다면 주먹인지 아닌지에 대한 값을 추가한다. : 명확한 변화를 반영하기 위함.
+        fistReader.append(isHandInFist ? !isPalmOpened : isFistShape)
+        
+        // 60프레임중 12프레임 연속으로 동일한 값을 추적하기 위한 프레임 threshold
+        if fistReader.count > 12 {
+            fistReader.removeFirst()
+        }
+        
+        // 판독 결과가 일관적일 때 상태 변경
+        if isAllSameResultOnFistReading(readingData: fistReader), fistReader.first != isHandInFist {
+            if chirality == .right {
+                isRightHandInFist = fistReader.first!
+                fistReaderRight = fistReader
             } else {
-                isRightHandInFist = isFistShape
+                isLeftHandInFist = fistReader.first!
+                fistReaderLeft = fistReader
             }
         } else {
-            if isLeftHandInFist {
-                isLeftHandInFist = !isPalmOpened
+            if chirality == .right {
+                fistReaderRight = fistReader
             } else {
-                isLeftHandInFist = isFistShape
+                fistReaderLeft = fistReader
             }
         }
+    }
+    
+    func isAllSameResultOnFistReading(readingData: [Bool]) -> Bool {
+        guard let firstData = readingData.first else { return false }
+        return readingData.allSatisfy { $0 == firstData }
     }
     
     func getJointPosition(_ jointName: HandSkeleton.JointName, chirality : Chirality) -> simd_float3 {

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel.swift
@@ -25,6 +25,9 @@ final class HandRollingStretchingViewModel: StretchingCounter {
     var isRightHandInFist = false
     var isLeftHandInFist = false
     
+    var fistReaderRight: [Bool] = []
+    var fistReaderLeft: [Bool] = []
+    
     let stretchingAttachmentViewID  = "StretchingAttachmentView"
     
     let frameInterval = 1

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
@@ -43,7 +43,8 @@ final class HandRollingTutorialViewModel {
     var rightRotationCollisionArray = [ false, false, false, false]
     
     var rightLaunchState = false
-    var leftLaunchState = false
+    
+    var fistReaderRight: [Bool] = []
     
     var rightHitCount = 0
     


### PR DESCRIPTION
# 이슈

# 작업 사항
문제사항 : 
엄지와 검지 손가락이 비전프로 카메라에 보이지 않을 때에, 트레킹이 풀리지 않고, 손모양을 편 상태로 비전프로가 추정하게 됨 => 즉, 주먹을 돌리다가 손목링이 해제되는 문제 

과거 대응 : 손바닥을 완전히 펴야지만 즉 특정 조인트간의 거리가 9센치 이상으로 벌어져야지만 손목링이 풀리는 식으로 적용했지만, 위의 문제 (즉, 특정 조인트가 카메라상으로 가려질 때에, 조인트가 펴있을 때의 동작으로 추정하는 ) 를 피하지 못함. 

현재 대응 : 60 프레임 중에 단 한 프레임에서, 특정조인트가 숨겨지면 손목링이 풀리는 현상에 대해서 총 12프레임동안 주먹인식이 어떻게 되었는지에 대한 변화값을 추적하여서 모두 동일해야지만 true, false로 변경하는 식으로 수정. 

즉, 주먹을 돌리는 중 isRightFistShape = true인데 이를 변경하려면, [false .... 12번 반복 ...., false ] 가 되어야지만 false로 변경할 수 있도록 고침. 

주먹을 돌리는 중은 [true, true, false, false, true ... true] 가 될 것이므로 손목링이 풀리지 않음. 

결과 : 
( 저의 손 기준으로 ) 주먹을 돌리다가 엄지 검지가 카메라에서 안보일 때에 주먹 인식 =true 를 유지하여, wristRing 렌더링을 유지하는 것으로 개선됨. 

# 고민 or 참고 사항 (선택)

# 스크린샷 (선택)
