### PR TITLE
Bug: 왼쪽손 손목 회전시 소리가 나지 않는 현상 해결

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
@@ -104,14 +104,14 @@ struct HandRollingStretchingView: View {
             let colorValueChangedTo = min (newValue * 2, 6)
             viewModel.getDifferentRingColor(viewModel.rightGuideRing, intChangeTo: Int32(colorValueChangedTo))
             Task {
-                await viewModel.playRotationChangeRingSound(newValue)
+                await viewModel.playRotationChangeRingSound(newValue, chirality: .right)
             }
         }
         .onChange(of: viewModel.leftRotationCount, initial: false ) { _, newValue in
             let colorValueChangedTo = min (newValue * 2 + 1, 7)
             viewModel.getDifferentRingColor(viewModel.leftGuideRing, intChangeTo: Int32(colorValueChangedTo))
             Task {
-                await viewModel.playRotationChangeRingSound(newValue)
+                await viewModel.playRotationChangeRingSound(newValue, chirality: .left)
             }
         }
         .onChange(of: viewModel.rightHitCount, initial: false ) { oldNumber, newNumber in

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+UpdateTransform.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+UpdateTransform.swift
@@ -123,13 +123,15 @@ extension HandRollingStretchingViewModel {
         return previous + (current - previous) * factor
     }
     
-    func playRotationChangeRingSound(_ newValue: Int) async {
+    func playRotationChangeRingSound(_ newValue: Int, chirality : Chirality) async {
+        
+        let guideRing = chirality == .left ? leftGuideRing : rightGuideRing
         if newValue >= 3 {
-            try? await playSpatialAudio(rightGuideRing, audioInfo: AudioFindHelper.handRotationThreeTimes)
+            try? await playSpatialAudio(guideRing, audioInfo: AudioFindHelper.handRotationThreeTimes)
         } else if newValue == 2 {
-            try? await playSpatialAudio(rightGuideRing, audioInfo: AudioFindHelper.handRotationTwice)
+            try? await playSpatialAudio(guideRing, audioInfo: AudioFindHelper.handRotationTwice)
         } else if newValue == 1 {
-            try? await playSpatialAudio(rightGuideRing, audioInfo: AudioFindHelper.handRotationOnce)
+            try? await playSpatialAudio(guideRing, audioInfo: AudioFindHelper.handRotationOnce)
         }
     }
 }


### PR DESCRIPTION
# 이슈
#54 

# 작업 사항
- 왼쪽 회전시 소리가 나지 않는 현상을 chirality 를 함수내에 반영하여, 어느쪽 손목엔티티의 스페이셜오디오에서 오디오를 재생해야하는지 설정하도록 변경. 

# 고민 or 참고 사항 (선택)

# 스크린샷 (선택)
