### PR TITLE
Fix/#45 make clone when entityon content

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+UpdateTransform.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+UpdateTransform.swift
@@ -23,10 +23,10 @@ extension HandRollingStretchingViewModel {
         
         rightTargetEntities[0].transform.translation = .init(x: -0.6, y: startingHeight - 0.2, z: -0.8)
         rightTargetEntities[1].transform.translation = .init(x: -0.6, y: startingHeight + 0.4, z: -1.0)
-        rightTargetEntities[2].transform.translation = .init(x: 0.8, y: startingHeight + 0.3 , z: -0.7)
+        rightTargetEntities[2].transform.translation = .init(x: 0.9, y: startingHeight + 0.3 , z: -0.7)
         
-        leftTargetEntities[0].transform.translation = .init(x: -0.35, y: startingHeight + 0.1, z: -1.0)
-        leftTargetEntities[1].transform.translation = .init(x: 0.4, y: startingHeight + 0.2, z: -1.0)
+        leftTargetEntities[0].transform.translation = .init(x: -0.35, y: startingHeight, z: -1.0)
+        leftTargetEntities[1].transform.translation = .init(x: 0.5, y: startingHeight + 0.2, z: -1.0)
         leftTargetEntities[2].transform.translation = .init(x: 0.9, y: startingHeight - 0.2, z: -0.6)
     }
     

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+UpdateTransform.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+UpdateTransform.swift
@@ -101,7 +101,7 @@ extension HandRollingStretchingViewModel {
         let intersection3D = middleKnucklePosition + normalizedVector * t
         
         let distanceToCenter = length(intersection3D - wristRingPosition)
-        if distanceToCenter <= ( radius / 4 )  {
+        if distanceToCenter <= ( radius / 8 )  {
             if chirality == .right {
                 rightGuideSphere.scale = .init(repeating: 0.01)
                 if rightRotationCount > 0 && !rightLaunchState {

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+SprialLaunching.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+SprialLaunching.swift
@@ -13,53 +13,55 @@ import RealityKitContent
 extension HandRollingTutorialViewModel {
     
     func generateLaunchObj(chirality: Chirality) async throws -> Entity {
-        if let custom3DObject = try? await Entity(named: "Hand/spiral_new", in: realityKitContentBundle) {
-            let rotationNumber = rightRotationForLaunchNumber
-            custom3DObject.name = "Spiral_\(chirality)_\(rotationNumber)"
-            
-            custom3DObject.components.set(GroundingShadowComponent(castsShadow: true))
-            custom3DObject.components.set(InputTargetComponent())
-            custom3DObject.generateCollisionShapes(recursive: true)
-            
-            custom3DObject.scale = .init(repeating: 0.01)
-            
-            let physicsMaterial = PhysicsMaterialResource.generate(
-                staticFriction: 0.01,
-                dynamicFriction: 0.01,
-                restitution: 1.5
-            )
-            
-            var physicsBody = PhysicsBodyComponent(massProperties: .default, material: physicsMaterial, mode: .dynamic)
-            physicsBody.isAffectedByGravity = false
-            physicsBody.massProperties.mass = 0.01
-            
-            let startingCriteria = rightGuideRing
-            custom3DObject.transform = startingCriteria.transform
-            
-            let forwardDirection = startingCriteria.transform.matrix.columns.0 // x axis
-            let direction = simd_float3(forwardDirection.x, forwardDirection.y, forwardDirection.z)
-            let adjustedTranslation = startingCriteria.position - direction * 0.25
-            
-            custom3DObject.transform.translation = adjustedTranslation
-            
-            if let modelEntity = custom3DObject.findEntity(named: "Spiral") as? ModelEntity {
-                modelEntity.components[PhysicsBodyComponent.self] = physicsBody
-            }
-            
-            try await animating(entity: custom3DObject, chirality: chirality)
-            
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                if chirality == .right {
-                    guard let indexOfEntity = self.rightEntities.firstIndex(where: { $0.name == custom3DObject.name}) else { return }
-                    self.rightEntities.remove(at: indexOfEntity)
-                }
-                custom3DObject.removeFromParent()
-            }
-            
-            return custom3DObject
+        if spiralOriginal.name == "" {
+            guard let spiralLoadedFromRCP = try? await Entity(named: "Hand/spiral_new", in: realityKitContentBundle) else { return Entity() }
+            spiralOriginal = spiralLoadedFromRCP
         }
         
-        return Entity()
+        let spiralEntity = spiralOriginal.clone(recursive: true)
+        let rotationNumber = rightRotationForLaunchNumber
+        spiralEntity.name = "Spiral_\(chirality)_\(rotationNumber)"
+        
+        spiralEntity.components.set(GroundingShadowComponent(castsShadow: true))
+        spiralEntity.components.set(InputTargetComponent())
+        spiralEntity.generateCollisionShapes(recursive: true)
+        
+        spiralEntity.scale = .init(repeating: 0.01)
+        
+        let physicsMaterial = PhysicsMaterialResource.generate(
+            staticFriction: 0.01,
+            dynamicFriction: 0.01,
+            restitution: 1.5
+        )
+        
+        var physicsBody = PhysicsBodyComponent(massProperties: .default, material: physicsMaterial, mode: .dynamic)
+        physicsBody.isAffectedByGravity = false
+        physicsBody.massProperties.mass = 0.01
+        
+        let startingCriteria = rightGuideRing
+        spiralEntity.transform = startingCriteria.transform
+        
+        let forwardDirection = startingCriteria.transform.matrix.columns.0 // x axis
+        let direction = simd_float3(forwardDirection.x, forwardDirection.y, forwardDirection.z)
+        let adjustedTranslation = startingCriteria.position - direction * 0.25
+        
+        spiralEntity.transform.translation = adjustedTranslation
+        
+        if let modelEntity = spiralEntity.findEntity(named: "Spiral") as? ModelEntity {
+            modelEntity.components[PhysicsBodyComponent.self] = physicsBody
+        }
+        
+        try await animating(entity: spiralEntity, chirality: chirality)
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            if chirality == .right {
+                guard let indexOfEntity = self.rightEntities.firstIndex(where: { $0.name == spiralEntity.name}) else { return }
+                self.rightEntities.remove(at: indexOfEntity)
+            }
+            spiralEntity.removeFromParent()
+        }
+        
+        return spiralEntity
     }
     
     func findResourceAndPlay(_ entity: Entity, spatialAudioName: String, resourceLocation: String, resourceFrom: String) async {

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
@@ -37,6 +37,10 @@ final class HandRollingTutorialViewModel {
     var rightEntities: [Entity] = []
     var rightTargetEntity : Entity = Entity()
     
+    var ringOriginal = Entity()
+    var spiralOriginal = Entity()
+    var targetRightOriginal = Entity()
+    
     var rightGuideRing = Entity()
     var rightGuideSphere = ModelEntity()
     
@@ -96,10 +100,18 @@ final class HandRollingTutorialViewModel {
     }
     
     func generateGuideRing(chirality : Chirality) async  -> Entity  {
-        guard let guideRingEntity = try? await Entity(named: "Hand/wrist_ring", in: realityKitContentBundle) else { return Entity() }
-        guideRingEntity.name = chirality == .right ?  "Ring_Right" : "Ring_Left"
+        var ringEntity = Entity()
         
-        return guideRingEntity
+        if ringOriginal.name == "" {
+            guard let guideRingEntityLoadedFromRCP = try? await Entity(named: "Hand/wrist_ring", in: realityKitContentBundle) else { return Entity() }
+            ringEntity = guideRingEntityLoadedFromRCP
+        } else {
+            ringEntity = ringOriginal.clone(recursive: true)
+        }
+        
+        ringEntity.name = chirality == .right ?  "Ring_Right" : "Ring_Left"
+        
+        return ringEntity
     }
     
     func generateGuideSphere(chirality : Chirality)-> ModelEntity  {


### PR DESCRIPTION
# 이슈
#45  #51 

# 작업 사항
- 발사체, 과녁, 손목링은 여러번 사용되는 오브젝트인데, 매번 RCP에서 로드하여 사용하던 방식을, 한번 로드한 오브젝트를 기억하고 이를 재활용(clone)하는 방식으로 수정하도록 방식을 변경 
- 발사가 잘되는 이슈가 있는데 이는, 발사한다로 인정되는 범위가 생각보다 넓어서 발생하는 이슈로 파악 -> 인정되는 범위를 1/4 => 1/8 로 줄임. (월요일 빈과 확인후 필요하다면 재수정) 

# 고민 or 참고 사항 (선택)

# 스크린샷 (선택)
