### PR TITLE
Fix: 스킵해도 오디오 재생되는 이슈 + 튜토리얼 상세조정 + 트렁케이션이슈

### DIFF
--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
@@ -83,8 +83,7 @@ struct HandRollingTutorialView : View {
         }
         .onChange(of: tutorialManager.currentStepIndex, initial: false ) { _, currentStepIndex in
             getNextTutorialStep(1)
-            getNextTutorialStep(2)
-            getNextTutorialStep(5)
+            getNextTutorialStep(4)
         }
         .onChange(of: viewModel.rightLaunchState, initial: false) { _, currentLaunchState in
             if currentLaunchState {
@@ -96,7 +95,7 @@ struct HandRollingTutorialView : View {
                 DispatchQueue.main.async {
                     viewModel.rightLaunchState = false
                     viewModel.rightRotationCount = 0
-                    getNextTutorialStep(4)
+                    getNextTutorialStep(3)
                 }
             }
         }
@@ -108,7 +107,7 @@ struct HandRollingTutorialView : View {
                 await viewModel.playRotationChangeRingSound(newValue)
             }
             
-            getNextTutorialStep(3)
+            getNextTutorialStep(2)
         }
         .onChange(of: viewModel.rightHitCount, initial: false ) { oldNumber, newNumber in
             if oldNumber < newNumber {

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -33,7 +33,7 @@ struct TutorialAttachmentView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.system(size: 32, weight: .medium))
                         .multilineTextAlignment(.leading)
-                        .lineLimit(3)
+                        .lineLimit(4)
                         .onAppear() {
                             tutorialManager.playInstructionAudio()
                         }
@@ -45,6 +45,7 @@ struct TutorialAttachmentView: View {
                     Button(tutorialManager.isLastStep ? "Done" : "Next") {
                         if tutorialManager.isLastStep {
                             tutorialManager.skip()
+                            tutorialManager.stopInstructionAudio()
                             appState.appPhase = .stretching
                         } else {
                             tutorialManager.advanceToNextStep()
@@ -86,6 +87,8 @@ struct TutorialAttachmentView: View {
             Divider()
             Button("Yes") {
                 tutorialManager.skip()
+                tutorialManager.stopInstructionAudio()
+                appState.appPhase = .stretching
             }
             .frame(maxWidth: .infinity, maxHeight: 44)
             .buttonStyle(.borderless)
@@ -95,7 +98,7 @@ struct TutorialAttachmentView: View {
             .frame(maxWidth: .infinity, maxHeight: 44)
             .buttonStyle(.borderless)
         }
-        .frame(width: 320, height: tutorialManager.stretchingPart == .wrist ? 270 : 240)
+        .frame(width: 320, height: 240)
         .padding(20)
         .glassBackgroundEffect()
     }

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -59,6 +59,9 @@ class TutorialManager {
            }
     }
     
+    func stopInstructionAudio() {
+        TutorialManager.audioPlayer?.stop()
+    }
 }
 
 extension TutorialManager {


### PR DESCRIPTION
# 이슈
close #59 

# 작업 사항
- 손목 튜토리얼 가이던스 완료에 대한 상세조정 
- Done 눌러도 가이던스 오디오가 계속 재생되는 이슈 보정 
- 손목 튜토리얼 중 3줄 이상의 텍스트가 나오는 경우, 트렁케이션 되는 이슈 보정 
- 튜토리얼 스킵버튼을 눌러도, 다음 스트레칭 화면으로 넘어가지 않는 이슈 보정 

# 고민 or 참고 사항 (선택)

# 스크린샷 (선택)
