### PR TITLE
튜토리얼 각 단계 완료시 오디오 재생 조건 추가 및 어깨 적용

### DIFF
--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -200,8 +200,20 @@ struct ShoulderStretchingTutorialView: View {
     }
     
     private func goToNextTutorialStep(_ currentStepIndex: Int) {
-        if tutorialManager.currentStepIndex == currentStepIndex {
-            tutorialManager.advanceToNextStep()
-        }
+        // 현재 단계인지 확인
+           if tutorialManager.currentStepIndex == currentStepIndex {
+               // 오디오가 재생 중인지 확인
+               if TutorialManager.audioPlayer?.isPlaying == true {
+                   // 오디오 재생 완료 후 다음 단계로 넘어가도록 설정
+                   tutorialManager.onAudioFinished = {
+                       DispatchQueue.main.async {
+                           tutorialManager.advanceToNextStep()
+                       }
+                   }
+               } else {
+                   // 오디오가 재생 중이 아니면 바로 다음 단계로 이동
+                   tutorialManager.advanceToNextStep()
+               }
+           }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -64,7 +64,7 @@ struct ShoulderStretchingTutorialView: View {
         }
         .onChange(of: viewModel.modelEntities) { _, newValue in
             if let _ = newValue.first(where: {$0.name.contains("rightModelEntity")}) {
-                completeTutorialStep(2)
+                goToNextTutorialStep(2)
             }
         }
     }
@@ -88,10 +88,10 @@ struct ShoulderStretchingTutorialView: View {
             if animationEvent.playbackController.entity?.name == "EntryRocket" {
                 viewModel.entryRocketEntity.removeFromParent()
                 viewModel.addRightHandAnchor()
-                completeTutorialStep(0) // Tutorial Step 0 Completed
+                goToNextTutorialStep(0) // Tutorial Step 0 Completed
             } else {
                 animationEvent.playbackController.entity?.removeFromParent()
-                completeTutorialStep(4)
+                goToNextTutorialStep(4)
                 executeCollisionAction()
             }
         }
@@ -126,7 +126,7 @@ struct ShoulderStretchingTutorialView: View {
 
             // 마지막 엔터티 감지
             if collidedModelEntity.name.contains("\(viewModel.numberOfObjects - 2)") {
-                completeTutorialStep(3)
+                goToNextTutorialStep(3)
                 
                 if tutorialManager.currentStepIndex >= 4  {
                     viewModel.addShoulderTimerEntity()
@@ -196,6 +196,12 @@ struct ShoulderStretchingTutorialView: View {
                     isStartWarningDone = true
                 }
             }
+        }
+    }
+    
+    private func goToNextTutorialStep(_ currentStepIndex: Int) {
+        if tutorialManager.currentStepIndex == currentStepIndex {
+            tutorialManager.advanceToNextStep()
         }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -61,6 +61,7 @@ struct TutorialAttachmentView: View {
                             
                         }
                         .font(.title3)
+                        .disabled(!currentStep.isCompleted)
                     }
                 }
                 .frame(width: 800, height: 300)

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -57,7 +57,7 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
                    TutorialManager.audioPlayer?.prepareToPlay()
                    TutorialManager.audioPlayer?.play()
 
-               }catch {
+               } catch {
                    print("Error on Playing Instruction Audio : \(error)")
                }
            }


### PR DESCRIPTION
# 이슈
- close #73 

# 작업 사항
- tutorialManager에서 audioPlayer의 재생완료 여부를 알기 위해 AVAudioPlayerDelegate를 채택하는데 이때 AVAudioPlayerDelegate 프로토콜의 메서드는 Actor 컨택스트를 보장하지 않으므로 @MainActor인 TutorialManager에서 실행하기 위해서 nonisolated 를 추가

- tutorial view에서 다음 단계로 넘어갈 시점에 advanceToNextStep를 호출하는데 그 시점이 tutorialManager에서 instruction이 재생이 완료 된 이후여야 하므로 onAudioFinished 콜백함수로 tutorialManager 에서 실행될 수 있게 함

- 어깨 스트레칭 뷰에서 기존에 update 클로저에서 1, 5 단계 완료 시키던것을 tutorialManager.currentStepIndex의 onChange에서 하도록 수정

- TutorialAttachmentView 에서도 tutorialManager.currentStepIndex의 onChange로 스텝 변화를 감지해서 오디오를 바로 play하기 때문에 스트레칭 뷰에서 completeTutorialStep 메서드에서 goToNextTutorialStep 에서 처럼 isPlaying으로 분기처리를 하게 되면 해당 step에서 audio가 재생되기도 전에 완료 상태로 될 수 있어서, 행동 요구조건이 없는 단계에서 실행되는 completeTutorialStep에서는 현재 재생중인지 검사 없이 콜백으로 전달해, 오디오 완료시에만 completeCurrentStep이 실행될 수 있게함

# 고민 or 참고 사항 (선택)
- 행동 조건이 있는 단계에서는 오디오가 다 재생되고, 조건이 달성 될 수 있으므로 오디오가 재생중이 아닐때에도 조건 달성시 다음단계로 가게했으나 조건이 없는 경우에도 같은 로직으로 구현을 했다가 오디오 실행코드가 TutorialAttachmentView의 onChange에서 실행되고, 스트레칭 뷰에서도 바로 완료 처리가 되기 때문에 오디오 재생 조건을 걸게 되면 오디오가 재생이 되기도 전에 완료가 될 수 있는 문제 (오디오 재생전에 next 버튼이 활성화 됨) 가 있었어서 트러블 슈팅이 조금 필요했습니다.

# 스크린샷 (선택)
