### PR TITLE
튜토리얼시 음성 완료 후 단계 넘어가도록 코드 수정

### DIFF
--- a/APPRO/APPRO/Model/StretchingPart.swift
+++ b/APPRO/APPRO/Model/StretchingPart.swift
@@ -61,7 +61,7 @@ enum StretchingPart: String, Identifiable, CaseIterable {
                 "Your mission is to lead the rocket to every stars and complete the journey. To see the stars, try to hold a fist. If you want to rearrange stars, hold a fist again.",
                 "Try to carry the rocket to the stars without moving your legs. Use only your arm's movement.",
                 "Good! This time, when you reach the space station, keep your arm in the same position for 5 seconds to refuel the rocket.",
-                "Great! Stretching your shoulder is the main focus in this content. Try to fix your position in one spot."
+                "Great! Stretching your shoulder is the main focus in this content. Try not to move your body around too much."
             ]
         }
     }

--- a/APPRO/APPRO/Model/TutorialStep.swift
+++ b/APPRO/APPRO/Model/TutorialStep.swift
@@ -11,7 +11,5 @@ struct TutorialStep {
     
     let instruction: String
     var isCompleted: Bool = false
-    let audioFilename: String
-    let isNextButtonRequired: Bool
-    
+    let audioFilename: String    
 }

--- a/APPRO/APPRO/Model/TutorialStep.swift
+++ b/APPRO/APPRO/Model/TutorialStep.swift
@@ -10,6 +10,5 @@ import Foundation
 struct TutorialStep {
     
     let instruction: String
-    var isCompleted: Bool = false
     let audioFilename: String    
 }

--- a/APPRO/APPRO/Views/Tutorial/Eye/EyeTutorialImmersiveView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Eye/EyeTutorialImmersiveView.swift
@@ -95,7 +95,7 @@ struct EyeTutorialImmersiveView: View {
     private func configureStep2() {
         tutorialManager.attachmentView.components.remove(ClosureComponent.self)
         
-        tutorialManager.completeCurrentStep()
+        tutorialManager.advanceToNextStep()
     }
     
     private func configureStep3(content: RealityViewContent) {
@@ -124,7 +124,7 @@ struct EyeTutorialImmersiveView: View {
         tutorialManager.playAppearAnimation(entity: ringEntity)
         tutorialManager.playAppearAnimation(entity: monitorEntity)
         
-        tutorialManager.completeCurrentStep()
+        tutorialManager.advanceToNextStep()
     }
     
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -206,19 +206,19 @@ struct ShoulderStretchingTutorialView: View {
     
     private func goToNextTutorialStep(_ currentStepIndex: Int) {
         // 현재 단계인지 확인
-           if tutorialManager.currentStepIndex == currentStepIndex {
-               // 오디오가 재생 중인지 확인
-               if TutorialManager.audioPlayer?.isPlaying == true {
-                   // 오디오 재생 완료 후 다음 단계로 넘어가도록 설정
-                   tutorialManager.onAudioFinished = {
-                       DispatchQueue.main.async {
-                           tutorialManager.advanceToNextStep()
-                       }
-                   }
-               } else {
-                   // 오디오가 재생 중이 아니면 바로 다음 단계로 이동
-                   tutorialManager.advanceToNextStep()
-               }
-           }
+        if tutorialManager.currentStepIndex == currentStepIndex {
+            // 오디오가 재생 중인지 확인
+            if TutorialManager.audioPlayer?.isPlaying == true {
+                // 오디오 재생 완료 후 다음 단계로 넘어가도록 설정
+                tutorialManager.onAudioFinished = {
+                    DispatchQueue.main.async {
+                        tutorialManager.advanceToNextStep()
+                    }
+                }
+            } else {
+                // 오디오가 재생 중이 아니면 바로 다음 단계로 이동
+                tutorialManager.advanceToNextStep()
+            }
+        }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -200,8 +200,20 @@ struct ShoulderStretchingTutorialView: View {
     }
     
     private func goToNextTutorialStep(_ currentStepIndex: Int) {
-        if tutorialManager.currentStepIndex == currentStepIndex {
-            tutorialManager.advanceToNextStep()
-        }
+        // 현재 단계인지 확인
+           if tutorialManager.currentStepIndex == currentStepIndex {
+               // 오디오가 재생 중인지 확인
+               if TutorialManager.audioPlayer?.isPlaying == true {
+                   // 오디오 재생 완료 후 다음 단계로 넘어가도록 설정
+                   tutorialManager.onAudioFinished = {
+                       DispatchQueue.main.async {
+                           tutorialManager.advanceToNextStep()
+                       }
+                   }
+               } else {
+                   // 오디오가 재생 중이 아니면 바로 다음 단계로 이동
+                   tutorialManager.advanceToNextStep()
+               }
+           }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -205,20 +205,8 @@ struct ShoulderStretchingTutorialView: View {
     }
     
     private func goToNextTutorialStep(_ currentStepIndex: Int) {
-        // 현재 단계인지 확인
         if tutorialManager.currentStepIndex == currentStepIndex {
-            // 오디오가 재생 중인지 확인
-            if TutorialManager.audioPlayer?.isPlaying == true {
-                // 오디오 재생 완료 후 다음 단계로 넘어가도록 설정
-                tutorialManager.onAudioFinished = {
-                    DispatchQueue.main.async {
-                        tutorialManager.advanceToNextStep()
-                    }
-                }
-            } else {
-                // 오디오가 재생 중이 아니면 바로 다음 단계로 이동
-                tutorialManager.advanceToNextStep()
-            }
+            tutorialManager.advanceToNextStep()
         }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -64,7 +64,7 @@ struct ShoulderStretchingTutorialView: View {
         }
         .onChange(of: viewModel.modelEntities) { _, newValue in
             if let _ = newValue.first(where: {$0.name.contains("rightModelEntity")}) {
-                completeTutorialStep(2)
+                goToNextTutorialStep(2)
             }
         }
     }
@@ -88,10 +88,10 @@ struct ShoulderStretchingTutorialView: View {
             if animationEvent.playbackController.entity?.name == "EntryRocket" {
                 viewModel.entryRocketEntity.removeFromParent()
                 viewModel.addRightHandAnchor()
-                completeTutorialStep(0) // Tutorial Step 0 Completed
+                goToNextTutorialStep(0) // Tutorial Step 0 Completed
             } else {
                 animationEvent.playbackController.entity?.removeFromParent()
-                completeTutorialStep(4)
+                goToNextTutorialStep(4)
                 executeCollisionAction()
             }
         }
@@ -126,7 +126,7 @@ struct ShoulderStretchingTutorialView: View {
 
             // 마지막 엔터티 감지
             if collidedModelEntity.name.contains("\(viewModel.numberOfObjects - 2)") {
-                completeTutorialStep(3)
+                goToNextTutorialStep(3)
                 
                 if tutorialManager.currentStepIndex >= 4  {
                     viewModel.addShoulderTimerEntity()
@@ -196,6 +196,12 @@ struct ShoulderStretchingTutorialView: View {
                     isStartWarningDone = true
                 }
             }
+        }
+    }
+    
+    private func goToNextTutorialStep(_ currentStepIndex: Int) {
+        if tutorialManager.currentStepIndex == currentStepIndex {
+            tutorialManager.advanceToNextStep()
         }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -205,8 +205,20 @@ struct ShoulderStretchingTutorialView: View {
     }
     
     private func goToNextTutorialStep(_ currentStepIndex: Int) {
-        if tutorialManager.currentStepIndex == currentStepIndex {
-            tutorialManager.advanceToNextStep()
-        }
+        // 현재 단계인지 확인
+           if tutorialManager.currentStepIndex == currentStepIndex {
+               // 오디오가 재생 중인지 확인
+               if TutorialManager.audioPlayer?.isPlaying == true {
+                   // 오디오 재생 완료 후 다음 단계로 넘어가도록 설정
+                   tutorialManager.onAudioFinished = {
+                       DispatchQueue.main.async {
+                           tutorialManager.advanceToNextStep()
+                       }
+                   }
+               } else {
+                   // 오디오가 재생 중이 아니면 바로 다음 단계로 이동
+                   tutorialManager.advanceToNextStep()
+               }
+           }
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -61,6 +61,7 @@ struct TutorialAttachmentView: View {
                             
                         }
                         .font(.title3)
+                        .disabled(!currentStep.isCompleted)
                     }
                 }
                 .frame(width: 800, height: 300)

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -49,19 +49,13 @@ struct TutorialAttachmentView: View {
                     
                     Spacer()
                     
-                    if let isNextButtonRequired = tutorialManager.currentStep?.isNextButtonRequired, isNextButtonRequired {
-                        Button(tutorialManager.isLastStep ? "Done" : "Next") {
-                            if tutorialManager.isLastStep {
-                                tutorialManager.skip()
-                                tutorialManager.stopInstructionAudio()
-                                appState.appPhase = .stretching
-                            } else {
-                                tutorialManager.advanceToNextStep()
-                            }
-                            
+                    if tutorialManager.isLastStep {
+                        Button("Done") {
+                            tutorialManager.skip()
+                            tutorialManager.stopInstructionAudio()
+                            appState.appPhase = .stretching
                         }
                         .font(.title3)
-                        .disabled(!currentStep.isCompleted)
                     }
                 }
                 .frame(width: 800, height: 300)

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -46,9 +46,7 @@ struct TutorialAttachmentView: View {
                         .onChange(of: tutorialManager.currentStepIndex, initial: false) { _, _ in
                             tutorialManager.playInstructionAudio()
                         }
-                    
-                    Spacer()
-                    
+                                        
                     if tutorialManager.isLastStep {
                         Button("Done") {
                             tutorialManager.skip()

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -42,11 +42,13 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
         guard !isLastStep else { return }
         /// 재생 후
         if isAudioFinished {
-            self.currentStepIndex += 1
+            currentStepIndex += 1
+            isAudioFinished = false
         } else {
             /// 재생 전, 중
             onAudioFinished = {
                 self.currentStepIndex += 1
+                self.isAudioFinished = false
             }
         }
     }
@@ -57,7 +59,6 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
     }
     
     func playInstructionAudio() {
-        isAudioFinished = false
         if let path = Bundle.main.path(forResource: currentStep?.audioFilename, ofType: "mp3"){
                do{
                    TutorialManager.audioPlayer = try AVAudioPlayer(contentsOf: URL(fileURLWithPath: path))

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -57,7 +57,7 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
                    TutorialManager.audioPlayer?.prepareToPlay()
                    TutorialManager.audioPlayer?.play()
 
-               }catch {
+               } catch {
                    print("Error on Playing Instruction Audio : \(error)")
                }
            }

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -40,11 +40,11 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
     func advanceToNextStep() {
         // 마지막 단계 일때는 스킵
         guard !isLastStep else { return }
-        /// 재생 전에 콜백은 nil
+        /// 재생 후
         if isAudioFinished {
             self.currentStepIndex += 1
         } else {
-            /// 재생 전, 후에
+            /// 재생 전, 중
             onAudioFinished = {
                 self.currentStepIndex += 1
             }

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -23,7 +23,8 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
     init(stretching: StretchingPart) {
         self.stretchingPart = stretching
         self.steps = stretching.tutorialInstructions.enumerated().map {
-            .init(instruction: $1, audioFilename: "\(stretching)_\($0 + 1)", isNextButtonRequired: TutorialManager.getNextButtonRequiredInfo(tutorialStretching: stretching)[$0]) }
+            .init(instruction: $1, audioFilename: "\(stretching)_\($0 + 1)" )
+        }
     }
     
     var isLastStep: Bool {
@@ -82,21 +83,6 @@ extension TutorialManager {
     
     static func isSkipped(part: StretchingPart) -> Bool {
         UserDefaults.standard.bool(forKey: "\(part)TutorialSkipped")
-    }
-    
-}
-
-extension TutorialManager {
-
-    static func getNextButtonRequiredInfo(tutorialStretching: StretchingPart) -> [Bool] {
-        switch tutorialStretching {
-        case .eyes:
-            [false, true, false, true]
-        case .wrist:
-            [false, true, false, false, true]
-        case .shoulder:
-            [false, true, false, false, false, true]
-        }
     }
     
 }


### PR DESCRIPTION
# 이슈
- close #73 

# 작업 사항
### @MartyTheGout의 코드 개선 의견 덕분에 코드를 개선하였고, next 버튼을 아예 제거 하는 것으로 변경되어 PR 을 다시 올립니다.

- tutorialManager에서 audioPlayer의 재생완료 여부를 알기 위해 AVAudioPlayerDelegate를 채택하는데 이때 AVAudioPlayerDelegate 프로토콜의 메서드는 Actor 컨택스트를 보장하지 않으므로 @MainActor인 TutorialManager에서 실행하기 위해서 nonisolated 를 추가

- tutorial view에서 다음 단계로 넘어갈 시점에 advanceToNextStep를 호출하는데 그 시점이 tutorialManager에서 instruction이 재생이 완료 된 이후여야 하므로 onAudioFinished 콜백함수로 tutorialManager 에서 실행될 수 있게 함

- 어깨 스트레칭 뷰에서 기존에 update 클로저에서 1, 5 단계 완료 시키던것을 tutorialManager.currentStepIndex의 onChange에서 하도록 수정 -> 5단계는 done버튼으로 넘어가도록 수정

- TutorialAttachmentView 에서도 tutorialManager.currentStepIndex의 onChange로 스텝 변화를 감지해서 오디오를 바로 play하기 때문에 스트레칭 뷰에서 ~~completeTutorialStep 메서드에서 goToNextTutorialStep 에서 처럼 isPlaying으로 분기처리를 하게 되면 해당 step에서 audio가 재생되기도 전에 완료 상태로 될 수 있어서, 행동 요구조건이 없는 단계에서 실행되는 completeTutorialStep에서는 현재 재생중인지 검사 없이 콜백으로 전달해, 오디오 완료시에만 completeCurrentStep이 실행될 수 있게함~~
advanceToNextStep 을 실행하면 tutorialManager 내부에서 오디오 재생 여부를 확인하여 넘어가도록 수정

### 추가사항
- 오디오 실행 상태를 처리하는 프로퍼티 isAudioFinished를 통해 오디오 실행이 완료 되었을때는 advanceToNextStep 실행시 바로 다음 단계로 가도록 하고
- 실행 중, 전 일때는 onAudioFinished에 다음 단계로 넘어가는 콜백 코드를 전달하여 오디오 재생이 완료되고 넘어가도록 함

# 고민 or 참고 사항 (선택)
- 행동 조건이 있는 경우 튜토리얼 매니저의 advanceToNextStep 실행시점이 오디오가 재생이 끝나고 난 다음에 (콜백 함수가 실행되고 난 뒤)일 수 있어서, 이를 구분하기 위해 isAudioFinished 프로퍼티를 추가해 오디오 완료를 구분하도록 했습니다.
``` swift
// 어깨 튜토리얼 뷰
 .onChange(of: tutorialManager.currentStepIndex, initial: false) { _, newValue in
            switch tutorialManager.currentStepIndex {
            case 1:
                tutorialManager.advanceToNextStep()
            case 4:
                viewModel.resetModelEntities()
                viewModel.createEntitiesOnEllipticalArc(handTransform: viewModel.rightHandTransform)
            default:
                break
            }
        }
        
        // 튜토리얼 attachmentView
        .onChange(of: tutorialManager.currentStepIndex, initial: false) { _, _ in
                            tutorialManager.playInstructionAudio()
                        }
                        
    // 튜토리얼 매니저                    
     func playInstructionAudio() {
        if let path = Bundle.main.path(forResource: currentStep?.audioFilename, ofType: "mp3"){
               do{
                   TutorialManager.audioPlayer = try AVAudioPlayer(contentsOf: URL(fileURLWithPath: path))
                   TutorialManager.audioPlayer?.delegate = self
                   TutorialManager.audioPlayer?.prepareToPlay()
                   TutorialManager.audioPlayer?.play()
               } catch {
                   print("Error on Playing Instruction Audio : \(error)")
               }
           }
           
            /// 행동 조건 완료시 실행
    func advanceToNextStep() {
        // 마지막 단계 일때는 스킵
        guard !isLastStep else { return }
        /// 재생 후
        if isAudioFinished {
            currentStepIndex += 1
        } else {
            /// 재생 전, 중
            onAudioFinished = {
                self.currentStepIndex += 1
            }
        }
    }
```

고민했던 부분이 어깨 뷰랑 attachmentView에서 둘다 currentStepIndex의 onChange로 조건이 걸려있는데 
순서가 오디오 재생이 먼저 되고 그다음에 advanceToNextStep() 가 실행이 되어야하는데 그렇지 않으면 advanceToNextStep에서 isAudioFinished 가 true인 상태에서 바로 다음 단계로 넘어갈 수 가 있어 아예  currentStepIndex += 1가 되고 바로 isAudioFinished = false 를 추가해 주었습니다.

# 스크린샷 (선택)
