### PR TITLE
Fix: 손목 튜토리얼 2단계에서 넘어가지 않는 버그 + 마지막단계에 왼쪽링이 나오지 않는 버그 해결

### DIFF
--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
@@ -67,9 +67,6 @@ struct HandRollingTutorialView : View {
                 if viewModel.isStartingObjectVisible { viewModel.isStartingObjectVisible = false}
                 
                 viewModel.rightEntities.append(viewModel.rightGuideRing)
-                if tutorialManager.currentStepIndex > 1 {
-                    viewModel.rightEntities.append(viewModel.rightGuideSphere)
-                }
                 
                 Task {
                     await viewModel.playSpatialAudio(viewModel.rightGuideRing, audioInfo: AudioFindHelper.handGuideRingAppear)
@@ -80,7 +77,7 @@ struct HandRollingTutorialView : View {
                 viewModel.rightEntities.removeAll()
             }
         }
-        .onChange(of: viewModel.isLeftHandInFist, initial: false) { _, isHandFistShape in            
+        .onChange(of: viewModel.isLeftHandInFist && tutorialManager.isLastStep, initial: false) { _, isHandFistShape in
             if isHandFistShape && tutorialManager.isLastStep {
                 viewModel.leftEntities.append(viewModel.leftGuideRing)
                 viewModel.leftEntities.append(viewModel.leftGuideSphere)
@@ -103,6 +100,10 @@ struct HandRollingTutorialView : View {
             if currentStepIndex == 1 {
                 viewModel.showTarget = true
                 goToNextTutorialStep(1)
+            }
+            
+            if tutorialManager.currentStepIndex == 2 {
+                viewModel.rightEntities.append(viewModel.rightGuideSphere)
             }
             
             if tutorialManager.isLastStep {

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
@@ -102,6 +102,7 @@ struct HandRollingTutorialView : View {
         .onChange(of: tutorialManager.currentStepIndex, initial: false ) { _, currentStepIndex in
             if currentStepIndex == 1 {
                 viewModel.showTarget = true
+                goToNextTutorialStep(1)
             }
             
             if tutorialManager.isLastStep {

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+HandTracking.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+HandTracking.swift
@@ -37,10 +37,14 @@ extension HandRollingTutorialViewModel {
                 
                 if anchor.chirality == .left {
                     latestHandTracking.left = anchor
-                    isHandInFistShape(chirality: .left)
+                    if !isLeftHandInFist {
+                        isHandInFistShape(chirality: .left)
+                    }
                 } else if anchor.chirality == .right {
                     latestHandTracking.right = anchor
-                    isHandInFistShape(chirality: .right)
+                    if !isRightHandInFist {
+                        isHandInFistShape(chirality: .right)
+                    }
                 }
                 
             default:

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -45,6 +45,7 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
             currentStepIndex += 1
             isAudioFinished = false
         } else {
+            
             /// 재생 전, 중
             onAudioFinished = {
                 self.currentStepIndex += 1
@@ -79,9 +80,9 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
     nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         if flag {
             Task { @MainActor in
+                isAudioFinished = true
                 onAudioFinished?() // 오디오 종료시 콜백 호출
                 onAudioFinished = nil // 콜백 초기화
-                isAudioFinished = true
             }
         }
     }


### PR DESCRIPTION
# 이슈
close #86 

# 작업 사항
-> 튜토리얼 2번째 단계에서 오디오 종료시 자동으로 다음단계로 진행되는 것을 예상했으나, 넘어가지 않음. => Next 버튼 클릭에서 없음으로 변경되어서, 이에 대한 여파로 벌어진 현상
-> view에서 현 튜토리얼 단계가 2단계 일때에, 다음 스텝으로 갈 수 있도록 함수 호출. 
-> Tutorial Manager 에서 단계 넘어가는 함수에 자잘한 순서 수정

-> 손 로직 변경하고나서, 튜토리얼 마지막단계에 왼쪽손 링이 나오지 않는 현상 해결 

# 고민 or 참고 사항 (선택)

# 스크린샷 (선택)
