### PR TITLE
ScenePhase 관련 에러 수정 

### DIFF
--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -47,10 +47,8 @@ struct APPROApp: App {
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
-            Task {
-                if (newPhase == .background || newPhase == .inactive) {
-                    appState.appPhase = .choosingStretchingPart
-                }
+            if (newPhase == .background || newPhase == .inactive) {
+                appState.appPhase = .choosingStretchingPart
             }
         }
 

--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -46,21 +46,22 @@ struct APPROApp: App {
                 }
             }
         }
+        .onChange(of: scenePhase) { _, newPhase in
+            Task {
+                if (newPhase == .background || newPhase == .inactive) {
+                    appState.appPhase = .choosingStretchingPart
+                }
+            }
+        }
+
         ImmersiveSpace(id: appState.immersiveSpaceID) {
-            if let stretchingPart = appState.currentStretchingPart {
+            if let stretchingPart = appState.currentStretchingPart, scenePhase == .active {
                 if appState.appPhase == .tutorial && !TutorialManager.isSkipped(part: stretchingPart) {
                     tutorialImmersiveView(part: stretchingPart)
                         .preferredSurroundingsEffect(.semiDark)
                 } else {
                     stretchingImmersiveView(part: stretchingPart)
                         .preferredSurroundingsEffect(appState.appPhase == .stretchingCompleted ? .ultraDark : .semiDark)
-                }
-            }
-        }
-        .onChange(of: scenePhase) { _, newPhase in
-            Task {
-                if (newPhase == .background || newPhase == .inactive) {
-                    appState.appPhase = .choosingStretchingPart
                 }
             }
         }

--- a/APPRO/APPRO/APPROApp.swift
+++ b/APPRO/APPRO/APPROApp.swift
@@ -41,16 +41,11 @@ struct APPROApp: App {
                     await openImmersiveSpace(id: appState.immersiveSpaceID)
                     dismissWindow(id: appState.stretchingPartsWindowID)
                 } else {
+                    openWindow(id: appState.stretchingPartsWindowID)
                     await dismissImmersiveSpace()
                 }
             }
         }
-        .onChange(of: appState.appPhase) { _, newPhase in
-            if newPhase == .choosingStretchingPart {
-                openWindow(id: appState.stretchingPartsWindowID)
-            }
-        }
-        
         ImmersiveSpace(id: appState.immersiveSpaceID) {
             if let stretchingPart = appState.currentStretchingPart {
                 if appState.appPhase == .tutorial && !TutorialManager.isSkipped(part: stretchingPart) {
@@ -59,6 +54,13 @@ struct APPROApp: App {
                 } else {
                     stretchingImmersiveView(part: stretchingPart)
                         .preferredSurroundingsEffect(appState.appPhase == .stretchingCompleted ? .ultraDark : .semiDark)
+                }
+            }
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            Task {
+                if (newPhase == .background || newPhase == .inactive) {
+                    appState.appPhase = .choosingStretchingPart
                 }
             }
         }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -69,7 +69,6 @@ struct ShoulderStretchingView: View {
     
     func subscribeToCollisionEvents(content: RealityViewContent) {
         guard let rightCollisionModel = viewModel.handRocketEntity.findEntity(named: "RocketCollisionModel") as? ModelEntity else { return }
-
             // 충돌 시작 감지
         _ = content.subscribe(to: CollisionEvents.Began.self, on: rightCollisionModel) { collisionEvent in
             setCollisionAction(collisionEvent: collisionEvent)

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
@@ -18,6 +18,7 @@ struct HandRollingTutorialView : View {
     
     var body : some View {
         RealityView { content, attachments in
+            viewModel.subscribeSceneEvent(content)
             let textEntity = createTextEntity("Stay aware of your surroundings")
             content.add(textEntity)
             setTutorialToStart(content: content)
@@ -218,7 +219,6 @@ struct HandRollingTutorialView : View {
                     
                     await viewModel.makeFirstEntitySetting()
                     viewModel.bringCollisionHandler(content)
-                    viewModel.subscribeSceneEvent(content)
                     isStartWarningDone = true
                 }
             }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -73,7 +73,6 @@ struct ShoulderStretchingTutorialView: View {
     
     func subscribeToCollisionEvents(content: RealityViewContent) {
         guard let rightCollisionModel = viewModel.handRocketEntity.findEntity(named: "RocketCollisionModel") as? ModelEntity else { return }
-        
         // 충돌 시작 감지
         _ = content.subscribe(to: CollisionEvents.Began.self, on: rightCollisionModel) { collisionEvent in
             setCollisionAction(collisionEvent: collisionEvent)

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -13,7 +13,6 @@ struct ShoulderStretchingTutorialView: View {
     @State private var tutorialManager = TutorialManager(stretching: .shoulder)
     @State private var viewModel = ShoulderStretchingTutorialViewModel()
     @State private var isColliding: Bool = false
-    
     @State var isStartWarningDone = false
     
     var body: some View {

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -18,6 +18,7 @@ struct ShoulderStretchingTutorialView: View {
     var body: some View {
         RealityView { content, attachments in
             content.add(viewModel.contentEntity)
+            viewModel.subscribeSceneEvent(content)
             let textEntity = createTextEntity("Stay aware of your surroundings")
             viewModel.contentEntity.addChild(textEntity)
             setTutorialToStart(content: content)
@@ -189,7 +190,6 @@ struct ShoulderStretchingTutorialView: View {
                     await viewModel.setEntryRocket()
                     viewModel.setHandRocketEntity()
                     subscribeToCollisionEvents(content: content)
-                    viewModel.subscribeSceneEvent(content)
                     isStartWarningDone = true
                 }
             }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
@@ -13,7 +13,6 @@ import ARKit
 @Observable
 @MainActor
 final class ShoulderStretchingTutorialViewModel {
-    
     var tutorialManager: TutorialManager?
     
     var contentEntity = Entity()

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
@@ -13,8 +13,6 @@ import ARKit
 @Observable
 @MainActor
 final class ShoulderStretchingTutorialViewModel {
-    var tutorialManager: TutorialManager?
-    
     var contentEntity = Entity()
     var modelEntities: [Entity] = []
     var handEntities: [Entity] = []

--- a/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialAttachmentView.swift
@@ -53,6 +53,7 @@ struct TutorialAttachmentView: View {
                             tutorialManager.stopInstructionAudio()
                             appState.appPhase = .stretching
                         }
+                        .disabled(!tutorialManager.isAudioFinished)
                         .font(.title3)
                     }
                 }

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -28,6 +28,12 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
         }
     }
     
+    deinit {
+        Task { @MainActor in
+            TutorialManager.audioPlayer?.stop()
+        }
+    }
+    
     var isLastStep: Bool {
         currentStepIndex == steps.count - 1
     }

--- a/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
+++ b/APPRO/APPRO/Views/Tutorial/TutorialManager.swift
@@ -30,7 +30,7 @@ class TutorialManager: NSObject, AVAudioPlayerDelegate {
     
     deinit {
         Task { @MainActor in
-            TutorialManager.audioPlayer?.stop()
+            TutorialManager.audioPlayer = nil
         }
     }
     


### PR DESCRIPTION
# 이슈
 - close #72 
# 작업 `사항`
### 1. ImmersiveSpace에서 크라운을 눌러 앱을 나갔다가 다시 들어왔을때 본 컨텐츠가 제대로 실행되지 않는 오류 수정
### 원인
```swift
enum AppPhase: Sendable, Equatable {
    
    case choosingStretchingPart
    case tutorial
    case stretching
    case stretchingCompleted
    
    var isImmersed: Bool {
        switch self {
        case .choosingStretchingPart:
            return false
        case .tutorial, .stretching, .stretchingCompleted:
            return true
        }
    }
    
}
```

AppPhase 가 위처럼 구현이 되어있어,  App파일에서 appPhase 에 따라 isImmersed 값이 변해 onChange에서 immersive를 키고 끄고 있습니다. 앱에서 윈도우에서 컨텐츠 카드를 눌렀을때, appState.appPhase = .tutorial 로 설정이 되는데 크라운 버튼으로 앱을 나갔을 경우, 이 appPhase 가 tutorial 상태로 되어있고, 앱을 다시 실행해 윈도우의 콘텐츠 카드를 다시 눌렀을때  appState.appPhase = .tutorial 로 입력되어 결국 appPhase의 isImmersed 값은 true로 그대로이기 때문에 App파일의 isImmersed에 따른  onChange 코드가 실행 되지 않아 immersive가 열리지 않았습니다. 

### 수정
그래서 App 파일에서 scenePhase를 활용해 scenePhase가 백그라운드 혹은 inactive가 되었을때 isImmersed가 false로 갈 수 있게, appPhase를 choosingStretchingPart가 되도록 하여 크라운을 눌러 앱을 나갔다가 다시 돌아오더라도 onChange로 immersiveSpace가 다시 열릴 수 있게 하였습니다.
다만 기존에 appPhase에 onChange가 걸려있고 choosingStretchingPart가 되면 윈도우가 열리도록 되어있어, scenePhase의 동작과 겹쳐서, 이를 삭제하고 isImmersed의 onChange에서 isImmersed가 false일때 openWindow가 실행되게 수정하였습니다.
-> isImmersed의 onChange에서만 윈도우, 스페이스 상태를 관리

### 2. ImmersiveSpace를 나갔을 때 오디오가 계속 재생되는 이슈 수정
### 원인
튜토리얼에서 ImmersiveSpace 상태를 나가도 이미 재생된 audioPlayer가 살아있어서, 계속 실행됨

### 수정
기존에 audioPlayer가 static으로 되어 있어서 audioPlayer가 살아있는건가 해서 static을 빼고도 테스트했는데 그건 아니였고, 
그래서 아예 static을 뺀 상태로 deinit에서 audioPlayer.stop()이 실행되게 했는데 
`Main actor-isolated property 'audioPlayer' can not be referenced from a nonisolated context`에러가 났고
 Task 로 MainActor에서 실행되게 했는데 audioPlayer이 static이 아닌 로컬 프로퍼티일 경우
` Capture of 'self' in a closure that outlives deinit; this is an error in the Swift 6 language mode` 라는 클로저에서 self를 캡쳐한다는 워닝이 떠서 기존처럼 static을 붙인 상태로 다시 수정하였습니다.

### 3. 어깨, 손목 에서 주의문구 실행시 immersive를 나갔을때 content 구독에서 발생되는 에러 수정
### 원인 
어깨, 손목에서 TextEntity가 띄워지고 일정시간 이후에 DispatchQueue.main.asyncAfter의 클로저를 실행하는데 클로저 실행 전에 홈 버튼을 눌러서 Immersive를 나가게 되면 나가진 상태에서 DispatchQueue.main.asyncAfter로 viewModel.subscribeSceneEvent가 실행되는데 이때 `Thread 1: Fatal error: Scene enountered outside ECS manager`라는 fatal error가 발생함

### 수정
viewModel.subscribeSceneEvent는 주변주의 문구가 띄워지는 것과 상관이 없어서 DispatchQueue.main.asyncAfter클로저가 아니라 realityView의 make클로저에서 실행되도록 수정

### 4. 튜토리얼 상태에서 강제로 나갔을 때 ImmersiveSpace의 본 컨텐츠 뷰가 실행되고 subscribeSceneEvent에서 3번과 같은 에러가 발생

### 원인
나갔을때 시스템에서 ImmersiveSpace 호출하는것 같은데.. 왜 그런지 모르겠습니다..
### 수정
우선 ImmersiveSpace내에 if scenePhase == .active 라는 조건문을 달아서 다른 상태에서 뷰가 띄워지지 않도록 하였습니다.

# 고민 or 참고 사항 (선택)
subscribeSceneEvent는 주의문구와 상관이 없어서 위치를 옮겼는데 어깨의 경우 텍스트가 띄워졌다가 사라지고 나가 오른손 로켓엔터티가 뜨고 그 로켓에 대한 collisionEvent를 구독하는 순서가 있어서 DispatchQueue.main.asyncAfter클로저에 구독 메서드를 넣었는데 테스트 결과 클로저 실행전에 ImmersiveSpace를 강제로 나가도 그 구독 메서드에서는 에러가 나지 않았습니다. 

클로저에서 실행시
에러 안남
content.subscribe(to: CollisionEvents.Ended.self, on: rightCollisionModel)
에러 남
content.subscribe(to: SceneEvents.Update.self, on: nil)
위 두 코드의 차이는 to 파라미터인데 결국 강제로 ImmersiveSpace를 나갔을때 영향을 받는게 to 파라미터에 따라 달라지는 것 같은데 정확한 원인은 아직 모르겠습니다.
