### PR TITLE
Fix/HandRolling Fix

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
@@ -14,13 +14,13 @@ struct HandRollingStretchingView: View {
     
     var body: some View {
         RealityView { content, attachments in
+            viewModel.subscribeSceneEvent(content)
             if viewModel.isStartingObjectVisible {
                 await viewModel.generateStartingObject(content)
             }
             await viewModel.makeFirstEntitySetting()
             viewModel.addEntity(content)
-            viewModel.bringCollisionHandler(content)
-            viewModel.subscribeSceneEvent(content)
+            viewModel.bringCollisionHandler(content)ㅇ
             viewModel.addAttachmentView(content, attachments)
             
         } update: { content, attachments in


### PR DESCRIPTION
# 이슈
- 손목 exit 했을 때에, Fatal Error 가 뜸. 
- 함수 호출 순서를 바꿈으로서 긴급개선가능. 

# 작업 사항

