### PR TITLE
튜토리얼 마지막 단계에서 왼쪽 손목에 나가는 스프링에 회전수가 제대로 반영되지 않는 이슈 

### DIFF
--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+SprialLaunching.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+SprialLaunching.swift
@@ -19,7 +19,7 @@ extension HandRollingTutorialViewModel {
         }
         
         let spiralEntity = spiralOriginal.clone(recursive: true)
-        let rotationNumber = rightRotationForLaunchNumber
+        let rotationNumber = chirality == .right ? rightRotationForLaunchNumber : leftRotationForLaunchNumber
         spiralEntity.name = "Spiral_\(chirality)_\(rotationNumber)"
         
         spiralEntity.components.set(GroundingShadowComponent(castsShadow: true))


### PR DESCRIPTION
# 이슈
- close #103 

# 작업 사항
- 튜토리얼 마지막에 왼쪽 스프링에 회전수가 제대로 반영되지 않는 버그
- 튜토리얼 상에서 나가는 스프링에 항상 오른쪽 회전수가 반영되는 에러 (자충수)를 발견 -> 왼쪽 회전수가 반영될수 있도록 수정. 
