### PR TITLE
어깨, 손목 worldTracking 로직 수정 및 어깨 기타 수정

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingView.swift
@@ -16,7 +16,6 @@ struct HandRollingStretchingView: View {
         RealityView { content, attachments in
             if viewModel.isStartingObjectVisible {
                 await viewModel.generateStartingObject(content)
-                viewModel.setClosureComponent(entity: viewModel.startObject)
             }
             await viewModel.makeFirstEntitySetting()
             viewModel.addEntity(content)

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+HandTracking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel+HandTracking.swift
@@ -12,11 +12,10 @@ import RealityKit
 extension HandRollingStretchingViewModel {
     func start() async {
         do {
-            if HandTrackingProvider.isSupported && WorldTrackingProvider.isSupported{
-                try await session.run([handTracking, worldTracking])
+            if HandTrackingProvider.isSupported {
+                try await session.run([handTracking])
             } else {
                 print("hand tracking: \(HandTrackingProvider.isSupported)")
-                print("world tracking: \(WorldTrackingProvider.isSupported)")
             }
             
         } catch {
@@ -94,13 +93,5 @@ extension HandRollingStretchingViewModel {
                 print("Session event \(event)")
             }
         }
-    }
-    
-    func setClosureComponent(entity: Entity) {
-        let component = ClosureComponent { [weak self] deltaTime in
-            guard self?.startingHeight == 0, let deviceAnchor = self?.worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else { return }
-            self?.startingHeight = deviceAnchor.originFromAnchorTransform.columns.3.y
-        }
-        entity.components.set(component)
     }
 }

--- a/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Hand/HandRollingStretchingViewModel.swift
@@ -13,14 +13,22 @@ import ARKit
 @Observable
 @MainActor
 final class HandRollingStretchingViewModel: StretchingCounter {
+    
+    private let headTracker = HeadTracker()
     //AR Session for hand tracking
     let session = ARKitSession()
     let sessionForWorldTracking = ARKitSession()
     
     var handTracking = HandTrackingProvider()
-    var worldTracking = WorldTrackingProvider()
     
-    var startingHeight: Float = 0.0
+    var startingHeight: Float {
+        guard let deviceAnchor = headTracker.worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else {
+            debugPrint("device anchor is nil")
+            return .init()
+        }
+        
+        return deviceAnchor.originFromAnchorTransform.translation().y
+    }
     
     var latestHandTracking: HandsUpdates = .init(left: nil, right: nil)
     

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -102,26 +102,31 @@ struct ShoulderStretchingView: View {
             return
         }
                 
-        // 충돌시 particle, audio 실행
-        viewModel.playEmitter(eventEntity: collidedModelEntity)
+        let entityNumber = Int(collidedModelEntity.name.dropFirst(4)) ?? 0
         
-        if let effect = ShoulderSoundEffects.allCases.first(where: { effect in
-            guard let entityNumber = Int(collidedModelEntity.name.dropFirst(4)) else { return false }
-            guard let effectNumber = Int(effect.rawValue.dropFirst(4)) else { return false }
-            // 나머지를 이용해 숫자를 대응
-            return (entityNumber - 1) % ShoulderSoundEffects.stars.count + 1 == effectNumber
-        }) {
-            viewModel.soundHelper.playSound(effect, on: collidedModelEntity)
-        }
-
-        // 다음 엔터티 일때만 Material 변경
-        if collidedModelEntity.name == "star\(viewModel.expectedNextNumber)" {
-            viewModel.changeMatreialColor(entity: collidedModelEntity)
-            viewModel.addExpectedNextNumber()
+        // 순서가 아닌 엔터티 일때 에미터, 소리 나오지 않도록 조건 수정
+        if entityNumber <= viewModel.expectedNextNumber {
+            viewModel.playEmitter(eventEntity: collidedModelEntity)
             
-            // 마지막 엔터티 감지
-            if collidedModelEntity.name.contains("\(viewModel.numberOfObjects - 1)") {
-                viewModel.addShoulderTimerEntity()
+            if let effect = ShoulderSoundEffects.allCases.first(where: { effect in
+                guard let effectNumber = Int(effect.rawValue.dropFirst(4)) else { return false }
+                // 나머지를 이용해 숫자를 대응
+                return (entityNumber - 1) % ShoulderSoundEffects.stars.count + 1 == effectNumber
+            }) {
+                viewModel.soundHelper.playSound(effect, on: collidedModelEntity)
+            } else {
+                viewModel.soundHelper.playSound(.star1, on: collidedModelEntity)
+            }
+
+            // 다음 엔터티 일때만 Material 변경
+            if collidedModelEntity.name == "star\(viewModel.expectedNextNumber)" {
+                viewModel.changeMatreialColor(entity: collidedModelEntity)
+                viewModel.addExpectedNextNumber()
+                
+                // 마지막 엔터티 감지
+                if collidedModelEntity.name.contains("\(viewModel.numberOfObjects - 1)") {
+                    viewModel.addShoulderTimerEntity()
+                }
             }
         }
     }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingView.swift
@@ -17,7 +17,6 @@ struct ShoulderStretchingView: View {
             content.add(viewModel.contentEntity)
             await viewModel.setEntryRocket()
             viewModel.setHandRocketEntity()
-            viewModel.setClosureComponent(entity: viewModel.handRocketEntity)
             subscribeToCollisionEvents(content: content)
             viewModel.addAttachmentView(content, attachments)
             viewModel.addShoulderTimerEntity()

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel+HandTraking.swift
@@ -12,8 +12,8 @@ import SwiftUI
 extension ShoulderStretchingViewModel {
     func startHandTrackingSession() async {
         do {
-            if HandTrackingProvider.isSupported && WorldTrackingProvider.isSupported {
-                try await session.run([handTrackingProvider, worldTrackingProvider])
+            if HandTrackingProvider.isSupported {
+                try await session.run([handTrackingProvider])
             }
         } catch {
             print("ARKitSession error:", error)
@@ -161,13 +161,5 @@ extension ShoulderStretchingViewModel {
             contentEntity.addChild(entity)
             handEntities.append(entity)
         }
-    }
-    
-    func setClosureComponent(entity: Entity) {
-        let component = ClosureComponent { [weak self] deltaTime in
-            guard let deviceAnchor = self?.worldTrackingProvider.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else { return }
-            self?.startingZ = deviceAnchor.originFromAnchorTransform.columns.3.z
-        }
-        entity.components.set(component)
     }
 }

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -292,11 +292,21 @@ final class ShoulderStretchingViewModel: StretchingCounter {
     
     func addAttachmentView(_ content: RealityViewContent, _ attachments: RealityViewAttachments) {
         guard let stretchingAttachmentView = attachments.entity(for: stretchingAttachmentViewID) else {
-            dump("StretchingAttachmentView not found in attachments!")
+            dump("TutorialAttachmentView not found in attachments!")
             return
         }
-        stretchingAttachmentView.position = .init(x: -0.5, y: 1.6 , z: -1.3)
+
+        guard let deviceAnchor = worldTrackingProvider.queryDeviceAnchor(atTimestamp: CACurrentMediaTime())
+        else {
+            debugPrint("deviceAnchor not found")
+            return
+        }
+        
+        let currentTranslation = deviceAnchor.originFromAnchorTransform.translation()
+        stretchingAttachmentView.position = .init(x: currentTranslation.x - 0.2, y: currentTranslation.y + 0.2, z: currentTranslation.z - 1.0)
+        
         content.add(stretchingAttachmentView)
+        
     }
     
     func showEndAttachmentView(_ content: RealityViewContent, _ attachments: RealityViewAttachments) {

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -269,7 +269,6 @@ final class ShoulderStretchingViewModel: StretchingCounter {
         if let rootEntity = try? await Entity(named: "Shoulder/RocketScene_New_Less.usda", in: realityKitContentBundle) {
             entryRocketEntity = rootEntity
             entryRocketEntity.name = "EntryRocket"
-            debugPrint("엔트리")
             entryRocketEntity.position = .init(x: startingTranslation.x + 0.2, y: startingTranslation.y + 0.3, z: -1)
             entryRocketEntity.transform.scale = .init(x: 0.1, y: 0.1, z: 0.1)
             entryRocketEntity.transform.rotation = .init(angle: .pi/2, axis: .init(x: 0, y: 1, z: 0))
@@ -306,7 +305,6 @@ final class ShoulderStretchingViewModel: StretchingCounter {
             dump("TutorialAttachmentView not found in attachments!")
             return
         }
-        debugPrint("어태치먼트")
         stretchingAttachmentView.position = .init(x: startingTranslation.x - 0.2, y: startingTranslation.y + 0.2, z: startingTranslation.z - 1.0)
         
         content.add(stretchingAttachmentView)

--- a/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
+++ b/APPRO/APPRO/Views/Stretchings/Shoulder/ShoulderStretchingViewModel.swift
@@ -156,6 +156,8 @@ final class ShoulderStretchingViewModel: StretchingCounter {
             guard let starModelEntity = self.starModelEntity?.clone(recursive: true) else { return }
             starModelEntity.name = "star\(idx+1)"
             starModelEntity.position = point
+            let rotationValue: Float = isRightSide ? -0.3 : 0.3
+            starModelEntity.transform.rotation = simd_quatf(angle: .pi/2 * rotationValue * Float(idx), axis: SIMD3<Float>(x: 0, y: 1, z: 0))
             starModelEntity.scale = SIMD3<Float>(repeating: 0.001)
             modelEntities.append(starModelEntity)
             contentEntity.addChild(starModelEntity)

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialView.swift
@@ -20,7 +20,7 @@ struct HandRollingTutorialView : View {
         RealityView { content, attachments in
             let textEntity = createTextEntity("Stay aware of your surroundings")
             content.add(textEntity)
-            setTutorialToStart(content: content)
+            setTutorialToStart(content, attachments)
         } update : { content, attachments in
             viewModel.addEntity(content)
             
@@ -38,10 +38,6 @@ struct HandRollingTutorialView : View {
                 if viewModel.isLeftHandInFist {
                     viewModel.updateGuideComponentsTransform(content, chirality: .left)
                 }
-                
-                viewModel.addAttachmentView(content, attachments)
-            } else {
-                
             }
         } attachments: {
             Attachment(id: viewModel.tutorialAttachmentViewID) {
@@ -192,7 +188,7 @@ struct HandRollingTutorialView : View {
         return textEntity
     }
     
-    private func setTutorialToStart(content: RealityViewContent) {
+    private func setTutorialToStart(_ content: RealityViewContent, _ attachments: RealityViewAttachments) {
         if tutorialManager.currentStepIndex == 0 {
             guard let textEntity = content.entities.first(where: { $0.name == "warning" })  else { return }
             withAnimation {
@@ -204,7 +200,7 @@ struct HandRollingTutorialView : View {
                     textEntity.removeFromParent()
                     if viewModel.isStartingObjectVisible {
                         await viewModel.generateStartingObject(content)
-                        viewModel.setClosureComponent(entity: viewModel.startObject)
+                        viewModel.addAttachmentView(content, attachments)
                     }
                     
                     await viewModel.makeFirstEntitySetting()

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+HandTracking.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel+HandTracking.swift
@@ -15,10 +15,9 @@ extension HandRollingTutorialViewModel {
     func start() async {
         do {
             if HandTrackingProvider.isSupported {
-                try await session.run([handTracking, worldTracking])
+                try await session.run([handTracking])
             } else {
                 print("hand tracking: \(HandTrackingProvider.isSupported)")
-                print("world tracking: \(WorldTrackingProvider.isSupported)")
             }
             
         } catch {
@@ -91,13 +90,5 @@ extension HandRollingTutorialViewModel {
                 print("Session event \(event)")
             }
         }
-    }
-    
-    func setClosureComponent(entity: Entity) {
-        let component = ClosureComponent { [weak self] deltaTime in
-            guard self?.startingHeight == 0, let deviceAnchor = self?.worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else { return }
-            self?.startingHeight = deviceAnchor.originFromAnchorTransform.columns.3.y
-        }
-        entity.components.set(component)
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Hand/HandRollingTutorialViewModel.swift
@@ -14,12 +14,20 @@ import ARKit
 @MainActor
 final class HandRollingTutorialViewModel {
     
+    private let headTracker = HeadTracker()
+    
     let session = ARKitSession()
     
     var handTracking = HandTrackingProvider()
-    var worldTracking = WorldTrackingProvider()
     
-    var startingHeight: Float = 0.0
+    var startingHeight: Float {
+        guard let deviceAnchor = headTracker.worldTracking.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else {
+            debugPrint("device anchor is nil")
+            return .init()
+        }
+        
+        return deviceAnchor.originFromAnchorTransform.translation().y
+    }
     
     var latestHandTracking: HandsUpdates = .init(left: nil, right: nil)
     

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -22,7 +22,9 @@ struct ShoulderStretchingTutorialView: View {
             viewModel.contentEntity.addChild(textEntity)
             setTutorialToStart(content, attachments)
         } update: { content, attachments in
-            viewModel.computeTransformHandTracking(currentStep: tutorialManager.currentStepIndex)
+            if !tutorialManager.isLastStep {
+                viewModel.computeTransformHandTracking(currentStep: tutorialManager.currentStepIndex)
+            }
         } attachments: {
             Attachment(id: viewModel.tutorialAttachmentViewID) {
                 TutorialAttachmentView(tutorialManager: tutorialManager)
@@ -79,6 +81,7 @@ struct ShoulderStretchingTutorialView: View {
                 viewModel.addRightHandAnchor()
                 tutorialManager.advanceToNextStep()
             } else {
+                // 타이머 애니메이션 종료시
                 animationEvent.playbackController.entity?.removeFromParent()
                 tutorialManager.advanceToNextStep()
                 executeCollisionAction()

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -180,7 +180,6 @@ struct ShoulderStretchingTutorialView: View {
                     textEntity.removeFromParent()
                     await viewModel.setEntryRocket()
                     viewModel.setHandRocketEntity()
-                    viewModel.setClosureComponent(entity: viewModel.entryRocketEntity)
                     subscribeToCollisionEvents(content: content)
                     isStartWarningDone = true
                     viewModel.addAttachmentView(content, attachments)

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialView.swift
@@ -20,19 +20,9 @@ struct ShoulderStretchingTutorialView: View {
             content.add(viewModel.contentEntity)
             let textEntity = createTextEntity("Stay aware of your surroundings")
             viewModel.contentEntity.addChild(textEntity)
-            setTutorialToStart(content: content)
+            setTutorialToStart(content, attachments)
         } update: { content, attachments in
-            if tutorialManager.currentStepIndex == 0 {
-                if isStartWarningDone {
-                    viewModel.computeTransformHandTracking(currentStep: tutorialManager.currentStepIndex)
-                    viewModel.addAttachmentView(content,attachments)
-                } else {
-                    viewModel.computeTransformHandTracking(currentStep: tutorialManager.currentStepIndex)
-                }
-            } else {
-                viewModel.computeTransformHandTracking(currentStep: tutorialManager.currentStepIndex)
-            }
-            
+            viewModel.computeTransformHandTracking(currentStep: tutorialManager.currentStepIndex)
         } attachments: {
             Attachment(id: viewModel.tutorialAttachmentViewID) {
                 TutorialAttachmentView(tutorialManager: tutorialManager)
@@ -178,7 +168,7 @@ struct ShoulderStretchingTutorialView: View {
         return textEntity
     }
     
-    func setTutorialToStart(content: RealityViewContent) {
+    func setTutorialToStart(_ content: RealityViewContent, _ attachments: RealityViewAttachments) {
         if tutorialManager.currentStepIndex == 0 {
             guard let textEntity = viewModel.contentEntity.findEntity(named: "warning") else { return }
             withAnimation {
@@ -190,9 +180,10 @@ struct ShoulderStretchingTutorialView: View {
                     textEntity.removeFromParent()
                     await viewModel.setEntryRocket()
                     viewModel.setHandRocketEntity()
-                    viewModel.setClosureComponent(entity: viewModel.handRocketEntity)
+                    viewModel.setClosureComponent(entity: viewModel.entryRocketEntity)
                     subscribeToCollisionEvents(content: content)
                     isStartWarningDone = true
+                    viewModel.addAttachmentView(content, attachments)
                 }
             }
         }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel+HandTraking.swift
@@ -89,7 +89,7 @@ extension ShoulderStretchingTutorialViewModel {
                     isEntryEnd = true
                     return
                 }
-                if currentStep >= 2{
+                if currentStep >= 2 {
                     resetModelEntities()
                     createEntitiesOnEllipticalArc(handTransform: self.rightHandTransform)
                 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel+HandTraking.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel+HandTraking.swift
@@ -12,8 +12,8 @@ import SwiftUI
 extension ShoulderStretchingTutorialViewModel {
     func startHandTrackingSession() async {
         do {
-            if HandTrackingProvider.isSupported && WorldTrackingProvider.isSupported{
-                try await session.run([handTrackingProvider, worldTrackingProvider])
+            if HandTrackingProvider.isSupported {
+                try await session.run([handTrackingProvider])
             }
         } catch {
             print("ARKitSession error:", error)
@@ -128,13 +128,5 @@ extension ShoulderStretchingTutorialViewModel {
             contentEntity.addChild(entity)
             handEntities.append(entity)
         }
-    }
-    
-    func setClosureComponent(entity: Entity) {
-        let component = ClosureComponent { [weak self] deltaTime in
-            guard let deviceAnchor = self?.worldTrackingProvider.queryDeviceAnchor(atTimestamp: CACurrentMediaTime()) else { return }
-            self?.startingZ = deviceAnchor.originFromAnchorTransform.columns.3.z
-        }
-        entity.components.set(component)
     }
 }

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
@@ -146,6 +146,8 @@ final class ShoulderStretchingTutorialViewModel {
             /// star1, star2...
             starModelEntity.name = "star\(idx+1)"
             starModelEntity.position = point
+            let rotationValue: Float = isRightSide ? -0.3 : 0.3
+            starModelEntity.transform.rotation = simd_quatf(angle: .pi/2 * rotationValue * Float(idx), axis: SIMD3<Float>(x: 0, y: 1, z: 0))
             starModelEntity.scale = SIMD3<Float>(repeating: 0.001)
             modelEntities.append(starModelEntity)
             contentEntity.addChild(starModelEntity)

--- a/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
+++ b/APPRO/APPRO/Views/Tutorial/Shoulder/ShoulderStretchingTutorialViewModel.swift
@@ -265,8 +265,18 @@ final class ShoulderStretchingTutorialViewModel {
             dump("TutorialAttachmentView not found in attachments!")
             return
         }
-        tutorialAttachmentView.position = .init(x: -0.5, y: 1.6 , z: -1.3)
+
+        guard let deviceAnchor = worldTrackingProvider.queryDeviceAnchor(atTimestamp: CACurrentMediaTime())
+        else {
+            debugPrint("deviceAnchor not found")
+            return
+        }
+        
+        let currentTranslation = deviceAnchor.originFromAnchorTransform.translation()
+        tutorialAttachmentView.position = .init(x: currentTranslation.x - 0.2, y: currentTranslation.y + 0.2, z: currentTranslation.z - 1.0)
+        
         content.add(tutorialAttachmentView)
+        
     }
     
     func playCustomAnimation(timerEntity: Entity) {


### PR DESCRIPTION
# 이슈
- close #121

# 작업 사항

### 어깨, 손목 WorldTracking 로직 수정
-  어깨에서 기존에 ClosureComponent를 사용해서 startingZ의 값을 업데이트 했던 것을 z값 뿐민 아니라 device의 translation을 가져오기 위해 startingTranslation 속성을 추가하고 headTracker 클래스를 사용하여 worldTrackingProvider에서 값을 가져와 startingTranslation를 계산 프로퍼티로 만들어서 translation 값을 계산하도록 적용

### 어깨 기타 수정
- attachmentView의 position에 worldTracking 위치 적용
- 별 모델이 사용자를 바라보도록 엔터티 rotation 값 수정
- 마지막 단계에서 핸드트래킹 계산 안하도록 수정
- 순서가 아닌 엔터티 일때 에미터, 소리 나오지 않도록 조건 수정
- SoundHelper에 조건에 맞는 effect가 없어도 소리 나오도록 수정

# 고민 or 참고 사항 (선택)
- 기존 방식에서는 기기의 위치에 맞게 position을 적용할때 worldTracking 세션을 실행하는 시점과 그 값을 실제로 position의 적용하는 시점의 순서가 보장되지 않아 값이 제대로 적용 안되는 문제가 있었습니다.
- worldTracking 세션을 실행은 RealityView의 task 모디파이어에서 이루어지고, 값이 position에 적용 되는 시점은 RealityView의 make 클로저에서 이루어져서 세션이 실행되기 전에 position의 값이 적용되기도 하고, worldTracking 세션을 실행하고 나서도 직후에는 deviceAnchor의 translation을 가져올 수 없었습니다.
- 그래서 headTracker 클래스의 인스턴스를 뷰 모델에 추가하여 Immersive 뷰에서 뷰모델이 초기화 될때 worldTracking이 먼저 실행되게 하고 그 값은 계산 프로퍼티로 계산되게 하여 실제 적용시 바로 적용 할 수 있도록 했습니다.

이 부분에 대해서 기기의 위치는 모든 부위에서 사용하다보니 그냥 ImmersvieSpace를 open하는 시점에 아예 worldTracking 세션을 시작하게 하는 것도 괜찮지 않을까 생각이 들었습니다.

이와 관련해서 피드백 주시면 감사하겠습니다.

# 스크린샷 (선택)
