### PR TITLE
눈 스트레칭 방해 오브젝트 위치값 조정

### DIFF
--- a/APPRO/APPRO/Views/Stretchings/Eye/EyeStretchingViewModel+Configure.swift
+++ b/APPRO/APPRO/Views/Stretchings/Eye/EyeStretchingViewModel+Configure.swift
@@ -45,7 +45,7 @@ extension EyeStretchingViewModel {
     }
     
     func setDisturbObjectsPosition() {
-        let positions = generateDisturbEntityPositions()
+        let positions = generateDisturbObjectPositions()
         
         guard disturbObjects.count == positions.count else {
             dump("Disturb Entities and positions count mismatch")
@@ -74,9 +74,9 @@ extension EyeStretchingViewModel {
         entity.components.set(closureComponent)
     }
     
-    private func generateDisturbEntityPositions() -> [Float3] {
-        let width: Float = 1.2
-        let height: Float = 0.8
+    private func generateDisturbObjectPositions() -> [Float3] {
+        let width: Float = 1.1
+        let height: Float = 0.7
         let dx: [Float] = [-1, 1, 1, -1]
         let dy: [Float] = [1, 1, -1, -1]
         var positions: Set<Float3> = []


### PR DESCRIPTION
# 이슈
- close #135 

# 작업 사항
- generateDisturbObjectPositions로 메서드 이름 수정
- width, height 값 조정

# 고민 or 참고 사항 (선택)
- 가장 위에 뜨는 오브젝트를 선택하려 할 때 제어 센터를 표시하는 버튼과 위치가 겹쳐 선택에 어려움이 있다는 피드백이 있어서 방해 오브젝트 위치값을 만드는 타원의 높이 값과 넓이 값을 약간 축소했습니다.
- 사람에 따라 현상의 발생 유무가 다르기 때문에 해당 현상을 겪은 팀원의 컨펌을 받아 값을 조정했습니다.

# 스크린샷 (선택)
없음
